### PR TITLE
Fixes 22: Expand all collapsed rows feature

### DIFF
--- a/bw_matchbox/assets/css/compare.css
+++ b/bw_matchbox/assets/css/compare.css
@@ -8,14 +8,18 @@
   --compare-selected-animation-time: 3s;
 }
 
+/* Root node */
+.compare.has-collapsed {
+  /* border: 1px solid red; */
+}
+
+/* Compare tables layout */
 .compare .compare-tables {
   width: 100%;
 }
-
 .compare .compare-tables > .column {
   position: relative;
 }
-
 .compare .compare-tables > .column + .column {
   /* Tables spacing */
   margin-left: 15px;

--- a/bw_matchbox/assets/css/compare.css
+++ b/bw_matchbox/assets/css/compare.css
@@ -8,9 +8,12 @@
   --compare-selected-animation-time: 3s;
 }
 
-/* Root node */
-.compare.has-collapsed {
-  /* border: 1px solid red; */
+/* Collapsed tools (shown only if collapsed rows are extist */
+.compare .collapsed-tools {
+  display: none;
+}
+.compare.has-collapsed .collapsed-tools {
+  display: block;
 }
 
 /* Compare tables layout */

--- a/bw_matchbox/assets/css/compare.css
+++ b/bw_matchbox/assets/css/compare.css
@@ -140,6 +140,12 @@
 }
 
 /* Adjust 'proxy' modal content styles */
+.common-modal-content#proxy-dialog-modal #proxy-table th:first-child {
+  width: 50%;
+}
+.common-modal-content#proxy-dialog-modal #proxy-table th:nth-child(2) {
+  width: 7em;
+}
 .common-modal-content#proxy-dialog-modal #proxy-table td:last-child div textarea {
   display: block;
   width: 100%;

--- a/bw_matchbox/assets/js/Compare/CompareCore.js
+++ b/bw_matchbox/assets/js/Compare/CompareCore.js
@@ -589,6 +589,12 @@ modules.define(
         document
           .getElementById('one-to-one')
           .addEventListener('click', this.createOneToOneProxyFunc.bind(this), false);
+
+        const expandAll = document.getElementById('expand-all-collapsed');
+        expandAll.addEventListener(
+          'click',
+          CompareRowsHelpers.expandAllCollapsedRows.bind(CompareRowsHelpers),
+        );
       },
 
       // Re-exported handlers for access from the html code (only core module is exposed as global)...

--- a/bw_matchbox/assets/js/Compare/CompareCore.js
+++ b/bw_matchbox/assets/js/Compare/CompareCore.js
@@ -241,6 +241,7 @@ modules.define(
           </tbody>
         `;
         document.getElementById(table_id).innerHTML = header + content;
+        CompareRowsHelpers.updateCollapsedState();
       },
 
       createOneToOneProxyFunc(event) {

--- a/bw_matchbox/assets/js/Compare/CompareRowsHelpers.js
+++ b/bw_matchbox/assets/js/Compare/CompareRowsHelpers.js
@@ -36,6 +36,22 @@ modules.define(
 
       // Methods...
 
+      updateCollapsedState() {
+        const rootNode = this.getRootNode();
+        const { collapsedRows } = this;
+        const collapsedCount = Object.values(collapsedRows).filter(Boolean).length;
+        // reduce((count, val) => {
+        //   return val ? ++count : count;
+        // }, 0);
+        const hasCollapsed = !!collapsedCount;
+        rootNode.classList.toggle('has-collapsed', hasCollapsed);
+      },
+
+      getRootNode() {
+        const rootNode = document.getElementById('compare-root');
+        return rootNode;
+      },
+
       /** getRowData -- Get row data
        * @param {<TRowKind>} rowKind
        * @param {<TRowId>} rowId
@@ -164,7 +180,7 @@ modules.define(
        */
       collapseRowByRecord(collapsedRowRecord) {
         // TODO: For paginated tables -- don't use saved elements (they would by dynamic)!
-        // See ` uncollapseRowByRecord` for example.
+        // See `uncollapseRowByRecord` for example.
         const { rowKind, rowId, rowEl } = collapsedRowRecord;
         const collapsedId = CompareRowsHelpers.getCollapsedId(rowKind, rowId);
         // Add styles...
@@ -181,6 +197,7 @@ modules.define(
         const parentNode = rowEl.parentNode;
         // Add handler before current row...
         parentNode.insertBefore(handlerRowEl, rowEl);
+        this.updateCollapsedState();
       },
 
       /** uncollapseRowByRecord -- Collapse particular row record
@@ -204,6 +221,7 @@ modules.define(
           rowEl.classList.remove('collapsed');
           rowEl.removeAttribute('collapsed-id');
         }
+        this.updateCollapsedState();
       },
 
       /** makeRowsCollapsed

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -52,9 +52,10 @@
 
 <script>
   modules.require('CompareCore', (CompareCore) => {
-    // Enable debug mode...
-    const useDebug = true;
-    // TODO: Expose it to global scope?
+    /* // Enable debug mode...
+     * const useDebug = true;
+     * // TODO: Expose it to global scope?
+     */
 
     // Global variables for compare tables feature (via global variable `sharedData`)...
     const sharedData = {
@@ -68,11 +69,12 @@
       source_node_location: '{{source_node.location}}',
     };
 
-    // DEBUG: Crop data table to easier debugging...
-    if (useDebug) {
-      sharedData.source_data.length = 2;
-      sharedData.target_data.length = 2;
-    }
+    /* // DEBUG: Crop data table to easier debugging...
+     * if (useDebug) {
+     *   sharedData.source_data.length = 2;
+     *   sharedData.target_data.length = 2;
+     * }
+     */
 
     /* // DEBUG: Emulate pre-collapsed elements data...
      * if (useDebug) {

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -33,7 +33,7 @@
     </div>
   </div>
   <div class="row collapsed-tools">
-    collapsed-tools
+    <button class="button-primary" id="expand-all-collapsed" onClick="">Expand all collapsed rows</button>
   </div>
   <div class="row compare-tables">
     <div class="column one-half">

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -16,7 +16,7 @@
   - `CompareCore` (from `bw_matchbox/assets/js/compare-core.js`)
 #}
 
-<div class="container compare">
+<div id="compare-root" class="container compare">
   {% include 'navigation.html' %}
   <div class="row">
     <div class="four columns">
@@ -31,6 +31,9 @@
     <button class="button-primary" id="save-mapping-button">{% if proxy and proxy != "None" %}Create Proxy</button>
     <button class="button-primary" id="one-to-one">1-to-1 Proxy</button>{% else %}Save{% endif %}</button>
     </div>
+  </div>
+  <div class="row collapsed-tools">
+    collapsed-tools
   </div>
   <div class="row compare-tables">
     <div class="column one-half">
@@ -49,10 +52,9 @@
 
 <script>
   modules.require('CompareCore', (CompareCore) => {
-    /* // Enable debug mode...
-     * const useDebug = true;
-     * // TODO: Expose it to global scope?
-     */
+    // Enable debug mode...
+    const useDebug = true;
+    // TODO: Expose it to global scope?
 
     // Global variables for compare tables feature (via global variable `sharedData`)...
     const sharedData = {
@@ -66,12 +68,11 @@
       source_node_location: '{{source_node.location}}',
     };
 
-    /* // DEBUG: Crop data table to easier debugging...
-     * if (useDebug) {
-     *   sharedData.source_data.length = 2;
-     *   sharedData.target_data.length = 2;
-     * }
-     */
+    // DEBUG: Crop data table to easier debugging...
+    if (useDebug) {
+      sharedData.source_data.length = 2;
+      sharedData.target_data.length = 2;
+    }
 
     /* // DEBUG: Emulate pre-collapsed elements data...
      * if (useDebug) {


### PR DESCRIPTION
- Issue 22: Expand all collapsed rows: Added button (shown only if some collapsed rows are exist), implemented code to expand all collapsed rows.
- Issue 22: Expand all collapsed rows: Implemented monitoring for the 'collapsed' state: check for `collapsedRows` after each change and update `.compare.has-collapsed` css class.