### PR TITLE
Fixes #41: Update filter API for processes list pages.

### DIFF
--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -14,8 +14,6 @@
 }
 
 /* Empty state: hode some elements... */
-/* .processes-list.empty .page-filters, */
-/* UNUSED: .processes-list.empty .table-pagination, */
 .processes-list.empty .processes-list-table {
   display: none;
 }
@@ -26,13 +24,28 @@
 }
 .processes-list.loading .page-search,
 .processes-list.loading .page-filters,
-/* UNUSED: .processes-list.loading .table-pagination, */
 .processes-list.loading .bottom-actions-links {
   opacity: 0.5;
   pointer-events: none;
 }
 .processes-list.loading .bottom-actions-links {
   opacity: 0;
+}
+
+/* Top radio groups... */
+.processes-list .page-filters {
+  line-height: 1;
+}
+.processes-list .page-filters > span,
+.processes-list .page-filters > span > span {
+  display: inline-block;
+  margin-right: 10px;
+}
+.processes-list .page-filters .radio-group-item {
+  white-space: nowrap;
+}
+.processes-list .page-filters .radio-group-item > label {
+  font-weight: normal;
 }
 
 /* Table */
@@ -126,8 +139,14 @@
 /* Show 'Reload' (after error) button if error... */
 .processes-list.error .bottom-actions-links a#action-clear-and-reload,
 /* Show 'Load more' button for all 'order by' values except for 'random'... */
-.processes-list:not(.order-random, .error) .bottom-actions-links a#action-load-more,
+.processes-list.has-more-data:not(.order-random, .error) .bottom-actions-links a#action-load-more,
 /* Show 'Refresh' button for 'random' 'order by' value... */
 .processes-list.order-random:not(.error) .bottom-actions-links a#action-reload-random {
   display: inline-block;
+}
+.processes-list .bottom-actions-links #available-records-info {
+  display: inline-block;
+}
+.processes-list .bottom-actions-links #available-records-info:not(:empty) {
+  margin-left: 0.5em;
 }

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesList.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesList.js
@@ -55,6 +55,14 @@ modules.define(
         ProcessesListDataLoad.loadData();
       },
 
+      /** Update value of 'filterBy' parameter from user */
+      onFilterByChange(target) {
+        // TODO: Move to Handlers module?
+        const { value } = target;
+        ProcessesListStates.setFilterBy(value);
+        ProcessesListDataLoad.loadData();
+      },
+
       /** clearAndReloadData -- Reload entire data (clear and load only first chunk)
        */
       clearAndReloadData() {

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
@@ -17,6 +17,10 @@ modules.define(
       processesApiUrl: '/processes',
       /** The number of records to retrieve at once and to display */
       pageSize: 25,
+      /** Default order value */
+      defaultOrderBy: 'random',
+      /** Default filter value */
+      defaultFilterBy: 'matched',
     };
 
     // Provide module...

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
@@ -2,10 +2,12 @@ modules.define(
   'ProcessesListData',
   [
     // Required modules...
+    'ProcessesListConstants',
   ],
   function provide_ProcessesListData(
     provide,
     // Resolved modules...
+    ProcessesListConstants,
   ) {
     // Define module...
 
@@ -19,7 +21,10 @@ modules.define(
       sharedParams: undefined,
 
       // Data params...
-      orderBy: 'random', // Control for `order_by` parameter (name, location, product; default (empty) -- random.
+
+      // Control for `order_by` parameter (name, location, product; default (empty) -- random.
+      orderBy: ProcessesListConstants.defaultOrderBy, // 'random' | 'name' | 'location' | 'product'
+      filterBy: ProcessesListConstants.defaultFilterBy, // 'matched' | 'unmatched' | 'waitlist'
       database: '',
       searchValue: '',
 

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -20,7 +20,7 @@
   - `ProcessesList` (from `bw_matchbox/assets/js/ProcessesList.js`)
 #}
 
-<div id="processes-list-root" class="container processes-list empty loading order-random">
+<div id="processes-list-root" class="container processes-list empty loading">
   {% include 'navigation.html' %}
   <div class="row">
     <div class="column">
@@ -28,18 +28,48 @@
         <p><input type="text" class="u-full-width" placeholder="Enter value to search" value="{{ query_string }}" id="query_string" /></p>
       </div>
       <div class="page-filters">
-        {# Controls for `order_by` parameter (name, location, product; default
-        is (empty) i.e. random (see `order-random` for `.processes-list` root
-        node. #}
-        <label class="radio-group-title">Order by:</label>
-        <input type="radio" name="order_by" id="order_by_random" value="" onChange="ProcessesList.onOrderByChange(this)" checked>
-        <label for="order_by_random">Random</label>
-        <input type="radio" name="order_by" id="order_by_name" value="name" onChange="ProcessesList.onOrderByChange(this)">
-        <label for="order_by_name">Name</label>
-        <input type="radio" name="order_by" id="order_by_location" value="location" onChange="ProcessesList.onOrderByChange(this)">
-        <label for="order_by_location">Location</label>
-        <input type="radio" name="order_by" id="order_by_product" value="product" onChange="ProcessesList.onOrderByChange(this)">
-        <label for="order_by_product">Product</label>
+        <span class="radio-group order-by">
+          {# Controls for `order_by` parameter (name, location, product;
+          default is (empty) i.e. random (see `order-random` for
+          `.processes-list` root node. #}
+          <span class="radio-group-title-wrapper">
+            <label class="radio-group-title">Order by:</label>
+          </span>
+          <span class="radio-group-item">
+            <input type="radio" name="order_by" id="order_by_random" value="random" onChange="ProcessesList.onOrderByChange(this)">
+            <label for="order_by_random">Random</label>
+          </span>
+          <span class="radio-group-item">
+            <input type="radio" name="order_by" id="order_by_name" value="name" onChange="ProcessesList.onOrderByChange(this)">
+            <label for="order_by_name">Name</label>
+          </span>
+          <span class="radio-group-item">
+            <input type="radio" name="order_by" id="order_by_location" value="location" onChange="ProcessesList.onOrderByChange(this)">
+            <label for="order_by_location">Location</label>
+          </span>
+          <span class="radio-group-item">
+            <input type="radio" name="order_by" id="order_by_product" value="product" onChange="ProcessesList.onOrderByChange(this)">
+            <label for="order_by_product">Product</label>
+          </span>
+        </span>
+        <span class="radio-group filter-by">
+          {# Controls for `filter` parameter: `matched`, `unmatched`, or `waitlist`. #}
+          <span class="radio-group-title-wrapper">
+            <label class="radio-group-title">Filter by:</label>
+          </span>
+          <span class="radio-group-item">
+            <input type="radio" name="filter_by" id="filter_by_matched" value="matched" onChange="ProcessesList.onFilterByChange(this)">
+            <label for="filter_by_matched">Matched</label>
+          </span>
+          <span class="radio-group-item">
+            <input type="radio" name="filter_by" id="filter_by_unmatched" value="unmatched" onChange="ProcessesList.onFilterByChange(this)">
+            <label for="filter_by_unmatched">Unmatched</label>
+          </span>
+          <span class="radio-group-item">
+            <input type="radio" name="filter_by" id="filter_by_waitlist" value="waitlist" onChange="ProcessesList.onFilterByChange(this)">
+            <label for="filter_by_waitlist">Waitlist</label>
+          </span>
+        </span>
       </div>
       <div id="processes-list-error" class="error">
         <!-- Error text comes here -->
@@ -60,7 +90,7 @@
       <div class="bottom-actions">
         <div class="bottom-actions-links">
           <a id="action-reload-random" onClick="ProcessesList.clearAndReloadData(this)">Reload random data</a>
-          <a id="action-load-more" onClick="ProcessesList.loadMoreData(this)">Load more</a>
+          <a id="action-load-more" onClick="ProcessesList.loadMoreData(this)">Load more<span id="available-records-info"></span></a>
           <a id="action-clear-and-reload" onClick="ProcessesList.clearAndReloadData(this)">Reload</a>
         </div>
         <div id="loader-splash" class="loader-splash full-cover"><div class="loader-spinner"></div></div>

--- a/bw_matchbox/bin/matchbox.py
+++ b/bw_matchbox/bin/matchbox.py
@@ -61,8 +61,9 @@ CHANGES_TEMPLATE = {
 def create_setup_files(filename, output_dir):
     if not filename.lower().endswith(".toml"):
         filename += ".toml"
-    with open(CWD / filename, "w") as f:
-        f.write(CONFIG_TEMPLATE.format(str(output_dir)))
+    with open(CWD / filename, "w", newline="\n") as f:
+        data = CONFIG_TEMPLATE.format(str(output_dir).replace('\\', '/'))
+        f.write(data)
         print("Created config file {}".format(CWD / filename))
 
 


### PR DESCRIPTION
- Issue #41: Update filter API for processes list pages: Added radio group for the `filter` parameter, added displaying of remain records inside the `Load more` button (eg: 'Load more(next NN out of NNN available)') (see `updateAvailableRecordsInfo` method of the `ProcessesListStates.js` module), added dynamic update of order and filter radio groups states based on default values (see `defaultOrderBy` and `defaultFilterBy` parameters in the `ProcessesListConstants.js` and `start` method of the `ProcessesListStates.js` modules), updated `/processes` request construction.

- Issue #1: Refactor: Write safe config file (`config.toml`) with unix-style line endings ('\n') and regular (unix-style) slashes in the `output_dir` file name (even on windows).