### PR TITLE
Fixes #45, #41: Added default ('none') filter option, database selector, `search` parameter into the `/processes` api request, total loaded records info block, some extra logic and fixes.

### DIFF
--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -61,6 +61,10 @@
 .processes-list .page-filters .radio-group-item > label {
   font-weight: normal;
 }
+.processes-list.has-search .radio-group.order-by {
+  pointer-events: none;
+  opacity: 0.5;
+}
 
 /* Table */
 .processes-list-table {

--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -17,6 +17,16 @@
 .processes-list.empty .processes-list-table {
   display: none;
 }
+.processes-list.loading .processes-list-table-empty,
+.processes-list:not(.empty) .processes-list-table-empty {
+  display: none;
+}
+.processes-list .processes-list-table-empty {
+  padding: 10px;
+  margin: 10px auto;
+  text-align: center;
+  opacity: 0.5;
+}
 
 /* Loading state: disable some elements... */
 .processes-list > * {
@@ -50,7 +60,7 @@
 
 /* Table */
 .processes-list-table {
-  margin-bottom: 0;
+  margin: 20px 0;
 }
 .processes-list-table tr td:last-child div > .button {
   display: block;
@@ -113,7 +123,7 @@
 /* Bottom actions */
 .processes-list .bottom-actions {
   position: relative;
-  min-height: 80px;
+  min-height: 60px;
   text-align: center;
   display: flex;
   justify-content: center;
@@ -145,8 +155,8 @@
   display: inline-block;
 }
 .processes-list .bottom-actions-links #available-records-info {
-  display: inline-block;
+  /* display: inline-block; */
 }
 .processes-list .bottom-actions-links #available-records-info:not(:empty) {
-  margin-left: 0.5em;
+  /* margin-left: 0.5em; */
 }

--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -143,14 +143,16 @@
 .processes-list .bottom-actions-links {
   transition: all var(--common-animation-time);
 }
-.processes-list .bottom-actions-links a {
+.processes-list .bottom-actions-links > * {
   display: none;
-  color: var(-layout-theme-primary-color-dark1);
-  cursor: pointer;
   margin: 0 10px;
 }
+.processes-list .bottom-actions-links > a {
+  color: var(--layout-theme-primary-color-dark1);
+  cursor: pointer;
+}
 .processes-list .bottom-actions-links a + a::before {
-  display: inline-block;
+  /* display: inline-block; */
 }
 .processes-list .bottom-actions-links a:hover {
   text-decoration: underline;
@@ -158,8 +160,10 @@
 /* Show 'Reload' (after error) button if error... */
 .processes-list.error .bottom-actions-links a#action-clear-and-reload,
 /* Show 'Load more' button for all 'order by' values except for 'random'... */
+.processes-list.has-more-data.has-search:not(.error) .bottom-actions-links a#action-load-more,
 .processes-list.has-more-data:not(.order-random, .error) .bottom-actions-links a#action-load-more,
+.processes-list:not(.has-more-data, .empty, .error) .bottom-actions-links span#show-total-records-number,
 /* Show 'Refresh' button for 'random' 'order by' value... */
-.processes-list.order-random:not(.error) .bottom-actions-links a#action-reload-random {
+.processes-list.order-random:not(.error, .has-search) .bottom-actions-links a#action-reload-random {
   display: inline-block;
 }

--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -54,6 +54,10 @@
 .processes-list .page-filters .radio-group-item {
   white-space: nowrap;
 }
+.processes-list .page-filters .radio-group-item-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
 .processes-list .page-filters .radio-group-item > label {
   font-weight: normal;
 }
@@ -123,7 +127,8 @@
 /* Bottom actions */
 .processes-list .bottom-actions {
   position: relative;
-  min-height: 60px;
+  margin: 10px 0;
+  min-height: 40px;
   text-align: center;
   display: flex;
   justify-content: center;
@@ -153,10 +158,4 @@
 /* Show 'Refresh' button for 'random' 'order by' value... */
 .processes-list.order-random:not(.error) .bottom-actions-links a#action-reload-random {
   display: inline-block;
-}
-.processes-list .bottom-actions-links #available-records-info {
-  /* display: inline-block; */
-}
-.processes-list .bottom-actions-links #available-records-info:not(:empty) {
-  /* margin-left: 0.5em; */
 }

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesList.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesList.js
@@ -44,7 +44,6 @@ modules.define(
     ];
 
     // global module variable
-    // eslint-disable-next-line no-unused-vars
     const ProcessesList = {
       // Proxy handlers...
 
@@ -96,9 +95,13 @@ modules.define(
       fetchUrlParams() {
         // Get & store the database value form the url query...
         const urlParams = CommonHelpers.parseQuery(window.location.search);
-        const { database, q: searchValue } = urlParams;
-        // Get database from url or from server-passed data... (Used only for `searchUrl` requests.)
-        ProcessesListData.database = database || ProcessesListData.sharedParams.database;
+        const {
+          // database, // UNUSED: #41: Using `databases` and `userDb`
+          q: searchValue,
+        } = urlParams;
+        /* // UNUSED: Get database from url or from server-passed data... (Used only for `searchUrl` requests.)
+         * ProcessesListData.database = database || ProcessesListData.sharedParams.database;
+         */
         ProcessesListData.searchValue = searchValue || '';
       },
 

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesList.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesList.js
@@ -46,6 +46,8 @@ modules.define(
     // global module variable
     // eslint-disable-next-line no-unused-vars
     const ProcessesList = {
+      // Proxy handlers...
+
       /** Update value of 'order by' parameter from user */
       onOrderByChange(target) {
         // TODO: Move to Handlers module?
@@ -61,6 +63,16 @@ modules.define(
         ProcessesListStates.setFilterBy(value);
         ProcessesListDataLoad.loadData();
       },
+
+      /** Update value of 'userDb' parameter from user */
+      onUserDbChange(target) {
+        // TODO: Move to Handlers module?
+        const { value } = target;
+        ProcessesListStates.setUserDb(value);
+        ProcessesListDataLoad.loadData();
+      },
+
+      // Data methods...
 
       /** clearAndReloadData -- Reload entire data (clear and load only first chunk)
        */
@@ -85,7 +97,7 @@ modules.define(
         // Get & store the database value form the url query...
         const urlParams = CommonHelpers.parseQuery(window.location.search);
         const { database, q: searchValue } = urlParams;
-        // Get database from url or from server-passed data...
+        // Get database from url or from server-passed data... (Used only for `searchUrl` requests.)
         ProcessesListData.database = database || ProcessesListData.sharedParams.database;
         ProcessesListData.searchValue = searchValue || '';
       },
@@ -117,8 +129,11 @@ modules.define(
 
       /** Start entrypoint */
       start(sharedParams) {
+        // Save shared data for future use...
         ProcessesListData.sharedParams = sharedParams;
+        // Fetch url query parameters...
         this.fetchUrlParams();
+        // Initialize all the modules...
         this.startAllModules();
         // Load data...
         ProcessesListDataLoad.loadData();

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesList.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesList.js
@@ -36,11 +36,10 @@ modules.define(
     const allModulesList = [
       ProcessesListConstants,
       ProcessesListData,
-      ProcessesListDataRender,
       ProcessesListNodes,
-      // ProcessesListPagination, // UNUSED: Using incremental data loading
       ProcessesListStates,
       ProcessesListSearch,
+      ProcessesListDataRender,
       ProcessesListDataLoad,
     ];
 
@@ -96,7 +95,7 @@ modules.define(
       startAllModules() {
         // Start all the modules...
         allModulesList.forEach((module) => {
-          if (typeof module.start === 'function') {
+          if (module && typeof module.start === 'function') {
             try {
               module.start();
               /* // Alternate option: Delayed start...
@@ -121,6 +120,8 @@ modules.define(
         ProcessesListData.sharedParams = sharedParams;
         this.fetchUrlParams();
         this.startAllModules();
+        // Load data...
+        ProcessesListDataLoad.loadData();
       },
     };
 

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
@@ -20,6 +20,7 @@ modules.define(
 
       /** Api base */
       processesApiUrl: '/processes',
+
       /** The number of records to retrieve at once and to display */
       pageSize: 25,
       /** Default order value */

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
@@ -15,6 +15,9 @@ modules.define(
     const ProcessesListConstants = {
       __id: 'ProcessesListConstants',
 
+      // DEBUG
+      useDebug: false, // Don't use it for production!
+
       /** Api base */
       processesApiUrl: '/processes',
       /** The number of records to retrieve at once and to display */
@@ -22,7 +25,9 @@ modules.define(
       /** Default order value */
       defaultOrderBy: 'random',
       /** Default filter value */
-      defaultFilterBy: 'none', // 'None'
+      defaultFilterBy: 'none',
+      /** Default userDb value */
+      defaultUserDb: 'source', // `Source` is the same as the server provided data
     };
 
     // Provide module...

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
@@ -13,6 +13,8 @@ modules.define(
      */
 
     const ProcessesListConstants = {
+      __id: 'ProcessesListConstants',
+
       /** Api base */
       processesApiUrl: '/processes',
       /** The number of records to retrieve at once and to display */
@@ -20,7 +22,7 @@ modules.define(
       /** Default order value */
       defaultOrderBy: 'random',
       /** Default filter value */
-      defaultFilterBy: 'unmatched',
+      defaultFilterBy: 'none', // 'None'
     };
 
     // Provide module...

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListConstants.js
@@ -15,8 +15,8 @@ modules.define(
     const ProcessesListConstants = {
       __id: 'ProcessesListConstants',
 
-      // DEBUG
-      useDebug: false, // Don't use it for production!
+      // DEBUG: useDebug -- specify debug mode. Don't use it for production!
+      useDebug: false,
 
       /** Api base */
       processesApiUrl: '/processes',

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
@@ -26,8 +26,9 @@ modules.define(
 
       // Control for `order_by` parameter (name, location, product; default (empty) -- random.
       orderBy: ProcessesListConstants.defaultOrderBy, // 'random' | 'name' | 'location' | 'product'
-      filterBy: ProcessesListConstants.defaultFilterBy, // 'matched' | 'unmatched' | 'waitlist'
-      database: '',
+      filterBy: ProcessesListConstants.defaultFilterBy, // 'none', 'matched' | 'unmatched' | 'waitlist'
+      userDb: ProcessesListConstants.defaultUserDb, // 'source' | 'target', 'proxy'
+      database: '', // Server provided database value (Used only for `searchUrl` requests.)
       searchValue: '',
 
       // Stored dom nodes...

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
@@ -17,6 +17,8 @@ modules.define(
     // global module variable
     // eslint-disable-next-line no-unused-vars
     const ProcessesListData = {
+      __id: 'ProcessesListData',
+
       // Owner page's provided data...
       sharedParams: undefined,
 

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
@@ -33,6 +33,7 @@ modules.define(
 
       // Stored dom nodes...
       searchBar: undefined,
+      hasSearch: false,
 
       // Page state...
       totalRecords: 0,

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListData.js
@@ -15,7 +15,6 @@ modules.define(
      */
 
     // global module variable
-    // eslint-disable-next-line no-unused-vars
     const ProcessesListData = {
       __id: 'ProcessesListData',
 
@@ -28,7 +27,7 @@ modules.define(
       orderBy: ProcessesListConstants.defaultOrderBy, // 'random' | 'name' | 'location' | 'product'
       filterBy: ProcessesListConstants.defaultFilterBy, // 'none', 'matched' | 'unmatched' | 'waitlist'
       userDb: ProcessesListConstants.defaultUserDb, // 'source' | 'target', 'proxy'
-      database: '', // Server provided database value (Used only for `searchUrl` requests.)
+      // database: '', // UNUSED: #41: Using `databases` and `userDb`. Server provided database value (Used only for `searchUrl` requests.)
       searchValue: '',
 
       // Stored dom nodes...

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
@@ -31,15 +31,15 @@ modules.define(
        * @param {object} [opts] - Options.
        * @param {boolean} [opts.update] - Update current data chunk.
        */
-      loadData(_opts = true) {
-        const { sharedParams } = ProcessesListData;
+      loadData(/* opts = {} */) {
+        const { currentPage, orderBy, filterBy, userDb, searchValue, sharedParams } = ProcessesListData;
         const { databases, database } = sharedParams;
         const { useDebug, defaultOrderBy, defaultFilterBy } = ProcessesListConstants;
         const { pageSize, processesApiUrl: urlBase } = ProcessesListConstants;
-        const { currentPage, orderBy, filterBy, userDb } = ProcessesListData;
         const userDbValue = databases[userDb]; // Could it be empty? Eg, to use: `|| database`
         const offset = currentPage * pageSize; // TODO!
         const params = {
+          search: searchValue, // TODO: Should the `order_by` parameter be disabled if the `search` parameter has used?
           database: userDbValue, // useDebug ? database : userDb || defaultUserDb,
           order_by: orderBy !== defaultOrderBy ? orderBy : '',
           filter: filterBy !== defaultFilterBy ? filterBy : '',
@@ -49,6 +49,7 @@ modules.define(
         const urlQuery = CommonHelpers.makeQuery(params, { addQuestionSymbol: true });
         const url = urlBase + urlQuery;
         console.log('[ProcessesListDataLoad:loadData]: start', {
+          searchValue,
           databases,
           userDbValue,
           useDebug,
@@ -111,7 +112,7 @@ modules.define(
             // Update total records number...
             ProcessesListData.totalRecords = totalRecords;
             // Append data to current table...
-            // TODO: Use `opts.update` to update last data chunk (?).
+            // TODO: Use `opts.update` to update (replace rows) last loaded data set.
             ProcessesListDataRender.renderTableData(data, { append: true });
             ProcessesListStates.setError(undefined); // Clear the error: all is ok
             ProcessesListStates.setHasData(ProcessesListData.hasData || hasData); // Update 'has data' flag

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
@@ -34,16 +34,10 @@ modules.define(
       loadData(_opts = true) {
         const { sharedParams } = ProcessesListData;
         const { databases, database } = sharedParams;
-        const { useDebug, defaultOrderBy, defaultFilterBy, defaultUserDb } = ProcessesListConstants;
+        const { useDebug, defaultOrderBy, defaultFilterBy } = ProcessesListConstants;
         const { pageSize, processesApiUrl: urlBase } = ProcessesListConstants;
-        const {
-          currentPage,
-          orderBy,
-          filterBy,
-          userDb,
-          // database, // UNUSED: Used for debug only?
-        } = ProcessesListData;
-        const userDbValue = databases[userDb] || database;
+        const { currentPage, orderBy, filterBy, userDb } = ProcessesListData;
+        const userDbValue = databases[userDb]; // Could it be empty? Eg, to use: `|| database`
         const offset = currentPage * pageSize; // TODO!
         const params = {
           database: userDbValue, // useDebug ? database : userDb || defaultUserDb,

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
@@ -25,36 +25,37 @@ modules.define(
     // global module variable
     // eslint-disable-next-line no-unused-vars
     const ProcessesListDataLoad = {
+      __id: 'ProcessesListDataLoad',
+
       /** Load next/current (?) data chunk
        * @param {object} [opts] - Options.
        * @param {boolean} [opts.update] - Update current data chunk.
        */
       loadData(_opts = true) {
-        const { defaultOrderBy } = ProcessesListConstants;
+        const { defaultOrderBy, defaultFilterBy } = ProcessesListConstants;
         const { pageSize, processesApiUrl: urlBase } = ProcessesListConstants;
         const { currentPage, database, orderBy, filterBy } = ProcessesListData;
         const offset = currentPage * pageSize; // TODO!
         const params = {
           database,
           order_by: orderBy !== defaultOrderBy ? orderBy : '',
-          filter: filterBy,
+          filter: filterBy !== defaultFilterBy ? filterBy : '',
           offset,
           limit: pageSize,
         };
         const urlQuery = CommonHelpers.makeQuery(params, { addQuestionSymbol: true });
         const url = urlBase + urlQuery;
-        /* console.log('[ProcessesListDataLoad:loadData]: start', {
-         *   url,
-         *   params,
-         *   urlQuery,
-         *   urlBase,
-         *   currentPage,
-         *   pageSize,
-         *   offset,
-         *   orderBy,
-         *   filterBy,
-         * });
-         */
+        console.log('[ProcessesListDataLoad:loadData]: start', {
+          url,
+          params,
+          urlQuery,
+          urlBase,
+          currentPage,
+          pageSize,
+          offset,
+          orderBy,
+          filterBy,
+        });
         ProcessesListStates.setLoading(true);
         fetch(url)
           .then((res) => {
@@ -127,11 +128,6 @@ modules.define(
             // Update all the page dynamic elements?
             ProcessesListStates.updatePage();
           });
-      },
-
-      /** Load first portion of data to display */
-      start() {
-        this.loadData();
       },
     };
 

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
@@ -32,22 +32,29 @@ modules.define(
        * @param {boolean} [opts.update] - Update current data chunk.
        */
       loadData(/* opts = {} */) {
-        const { currentPage, orderBy, filterBy, userDb, searchValue, sharedParams } = ProcessesListData;
+        const { currentPage, orderBy, filterBy, userDb, searchValue, sharedParams, hasSearch } =
+          ProcessesListData;
         const { databases, database } = sharedParams;
-        const { useDebug, defaultOrderBy, defaultFilterBy } = ProcessesListConstants;
-        const { pageSize, processesApiUrl: urlBase } = ProcessesListConstants;
+        const {
+          pageSize,
+          processesApiUrl: urlBase,
+          useDebug,
+          defaultOrderBy,
+          defaultFilterBy,
+        } = ProcessesListConstants;
         const userDbValue = databases[userDb]; // Could it be empty? Eg, to use: `|| database`
         const offset = currentPage * pageSize; // TODO!
         const params = {
           search: searchValue, // TODO: Should the `order_by` parameter be disabled if the `search` parameter has used?
           database: userDbValue, // useDebug ? database : userDb || defaultUserDb,
-          order_by: orderBy !== defaultOrderBy ? orderBy : '',
+          order_by: !hasSearch && orderBy !== defaultOrderBy ? orderBy : '',
           filter: filterBy !== defaultFilterBy ? filterBy : '',
           offset,
           limit: pageSize,
         };
         const urlQuery = CommonHelpers.makeQuery(params, { addQuestionSymbol: true });
         const url = urlBase + urlQuery;
+        // DEBUG: Using temporarily while working with requests (issues #41, #45, etc)...
         console.log('[ProcessesListDataLoad:loadData]: start', {
           searchValue,
           databases,
@@ -65,7 +72,6 @@ modules.define(
           orderBy,
           filterBy,
         });
-        debugger;
         ProcessesListStates.setLoading(true);
         fetch(url)
           .then((res) => {
@@ -110,7 +116,8 @@ modules.define(
              * });
              */
             // Update total records number...
-            ProcessesListData.totalRecords = totalRecords;
+            // ProcessesListData.totalRecords = totalRecords;
+            ProcessesListStates.setTotalRecordsCount(totalRecords);
             // Append data to current table...
             // TODO: Use `opts.update` to update (replace rows) last loaded data set.
             ProcessesListDataRender.renderTableData(data, { append: true });

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
@@ -23,7 +23,6 @@ modules.define(
      */
 
     // global module variable
-    // eslint-disable-next-line no-unused-vars
     const ProcessesListDataLoad = {
       __id: 'ProcessesListDataLoad',
 
@@ -34,7 +33,10 @@ modules.define(
       loadData(/* opts = {} */) {
         const { currentPage, orderBy, filterBy, userDb, searchValue, sharedParams, hasSearch } =
           ProcessesListData;
-        const { databases, database } = sharedParams;
+        const {
+          databases,
+          // database, // UNUSED: #41: Using `databases` and `userDb`.
+        } = sharedParams;
         const {
           pageSize,
           processesApiUrl: urlBase,
@@ -61,7 +63,7 @@ modules.define(
           userDbValue,
           useDebug,
           userDb,
-          database,
+          // database, // UNUSED: #41: Using `databases` and `userDb`.
           url,
           params,
           urlQuery,

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
@@ -32,12 +32,21 @@ modules.define(
        * @param {boolean} [opts.update] - Update current data chunk.
        */
       loadData(_opts = true) {
-        const { defaultOrderBy, defaultFilterBy } = ProcessesListConstants;
+        const { sharedParams } = ProcessesListData;
+        const { databases, database } = sharedParams;
+        const { useDebug, defaultOrderBy, defaultFilterBy, defaultUserDb } = ProcessesListConstants;
         const { pageSize, processesApiUrl: urlBase } = ProcessesListConstants;
-        const { currentPage, database, orderBy, filterBy } = ProcessesListData;
+        const {
+          currentPage,
+          orderBy,
+          filterBy,
+          userDb,
+          // database, // UNUSED: Used for debug only?
+        } = ProcessesListData;
+        const userDbValue = databases[userDb] || database;
         const offset = currentPage * pageSize; // TODO!
         const params = {
-          database,
+          database: userDbValue, // useDebug ? database : userDb || defaultUserDb,
           order_by: orderBy !== defaultOrderBy ? orderBy : '',
           filter: filterBy !== defaultFilterBy ? filterBy : '',
           offset,
@@ -46,6 +55,11 @@ modules.define(
         const urlQuery = CommonHelpers.makeQuery(params, { addQuestionSymbol: true });
         const url = urlBase + urlQuery;
         console.log('[ProcessesListDataLoad:loadData]: start', {
+          databases,
+          userDbValue,
+          useDebug,
+          userDb,
+          database,
           url,
           params,
           urlQuery,
@@ -56,6 +70,7 @@ modules.define(
           orderBy,
           filterBy,
         });
+        debugger;
         ProcessesListStates.setLoading(true);
         fetch(url)
           .then((res) => {

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataRender.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataRender.js
@@ -17,7 +17,6 @@ modules.define(
      */
 
     // global module variable
-    // eslint-disable-next-line no-unused-vars
     const ProcessesListDataRender = {
       clearTableData() {
         const tBodyNode = ProcessesListNodes.getTBodyNode();

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListNodes.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListNodes.js
@@ -17,7 +17,6 @@ modules.define(
      */
 
     // global module variable
-    // eslint-disable-next-line no-unused-vars
     const ProcessesListNodes = {
       getSearchBarNode() {
         const node = document.getElementById('query_string');

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListPagination.UNUSED.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListPagination.UNUSED.js
@@ -28,7 +28,6 @@ modules.define(
      */
 
     // global module variable
-    // eslint-disable-next-line no-unused-vars
     const ProcessesListPagination = {
       // TODO: `ProcessesListPagination` should be exposed to global scope or `onNavigationClick` should be proxied.
       renderNavigationLink(id, text) {

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListSearch.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListSearch.js
@@ -60,21 +60,14 @@ modules.define(
 
       /** Apply search */
       doSearch() {
-        // const { database } = ProcessesListData;
-        const { searchUrl } = ProcessesListData.sharedParams;
         const searchBar = ProcessesListNodes.getSearchBarNode();
         const searchValue = searchBar.value;
-        // TODO: pare search value with previous (if exists)?
+        // If value had changed...
         if (searchValue !== ProcessesListData.searchValue) {
           const hasSearch = !!searchValue;
           ProcessesListStates.setHasSearch(hasSearch);
           ProcessesListData.searchValue = searchValue; // Useless due to following redirect
-          console.log('[ProcessesListSearch:doSearch]', {
-            hasSearch,
-            searchValue,
-            searchUrl,
-          });
-          debugger;
+          ProcessesListStates.clearData();
           ProcessesListDataLoad.loadData();
         }
         return false;

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListSearch.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListSearch.js
@@ -4,14 +4,18 @@ modules.define(
     // Required modules...
     'CommonHelpers',
     'ProcessesListData',
+    'ProcessesListDataLoad',
     'ProcessesListNodes',
+    'ProcessesListStates',
   ],
   function provide_ProcessesListSearch(
     provide,
     // Resolved modules...
     CommonHelpers,
     ProcessesListData,
+    ProcessesListDataLoad,
     ProcessesListNodes,
+    ProcessesListStates,
   ) {
     // Define module...
 
@@ -21,8 +25,10 @@ modules.define(
     // global module variable
     // eslint-disable-next-line no-unused-vars
     const ProcessesListSearch = {
-      /** Go to the search page (TODO: to refactor?) */
-      doSearch() {
+      __id: 'ProcessesListSearch',
+
+      /** UNUSED (old approach): Go to the search page (TODO: to refactor?) */
+      doSearchRedirect() {
         const { database } = ProcessesListData;
         const { searchUrl } = ProcessesListData.sharedParams;
         const searchBar = ProcessesListNodes.getSearchBarNode();
@@ -48,6 +54,28 @@ modules.define(
            * });
            */
           location.assign(url);
+        }
+        return false;
+      },
+
+      /** Apply search */
+      doSearch() {
+        // const { database } = ProcessesListData;
+        const { searchUrl } = ProcessesListData.sharedParams;
+        const searchBar = ProcessesListNodes.getSearchBarNode();
+        const searchValue = searchBar.value;
+        // TODO: pare search value with previous (if exists)?
+        if (searchValue !== ProcessesListData.searchValue) {
+          const hasSearch = !!searchValue;
+          ProcessesListStates.setHasSearch(hasSearch);
+          ProcessesListData.searchValue = searchValue; // Useless due to following redirect
+          console.log('[ProcessesListSearch:doSearch]', {
+            hasSearch,
+            searchValue,
+            searchUrl,
+          });
+          debugger;
+          ProcessesListDataLoad.loadData();
         }
         return false;
       },

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListSearch.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListSearch.js
@@ -23,40 +23,40 @@ modules.define(
      */
 
     // global module variable
-    // eslint-disable-next-line no-unused-vars
     const ProcessesListSearch = {
       __id: 'ProcessesListSearch',
 
-      /** UNUSED (old approach): Go to the search page (TODO: to refactor?) */
-      doSearchRedirect() {
-        const { database } = ProcessesListData;
-        const { searchUrl } = ProcessesListData.sharedParams;
-        const searchBar = ProcessesListNodes.getSearchBarNode();
-        const searchValue = searchBar && searchBar.value;
-        // TODO: pare search value with previous (if exists)?
-        if (searchValue !== ProcessesListData.searchValue) {
-          ProcessesListData.searchValue = searchValue; // Useless due to following redirect
-          // If searchValue is empty, then go to index (processes-list, root) page, else -- to the search page...
-          const urlParams = {
-            database,
-            q: searchValue,
-          };
-          const urlQuery = CommonHelpers.makeQuery(urlParams, { addQuestionSymbol: true });
-          const urlBase = searchValue ? searchUrl : '/';
-          const url = urlBase + urlQuery;
-          /* console.log('[ProcessesListSearch:doSearch]', {
-           *   url,
-           *   urlQuery,
-           *   urlParams,
-           *   urlBase,
-           *   searchValue,
-           *   searchUrl,
-           * });
-           */
-          location.assign(url);
-        }
-        return false;
-      },
+      /* [>* UNUSED (old approach): Go to the search page (TODO: to refactor?) <]
+       * doSearchRedirect() {
+       *   const { database } = ProcessesListData;
+       *   const { searchUrl } = ProcessesListData.sharedParams;
+       *   const searchBar = ProcessesListNodes.getSearchBarNode();
+       *   const searchValue = searchBar && searchBar.value;
+       *   // TODO: pare search value with previous (if exists)?
+       *   if (searchValue !== ProcessesListData.searchValue) {
+       *     ProcessesListData.searchValue = searchValue; // Useless due to following redirect
+       *     // If searchValue is empty, then go to index (processes-list, root) page, else -- to the search page...
+       *     const urlParams = {
+       *       database,
+       *       q: searchValue,
+       *     };
+       *     const urlQuery = CommonHelpers.makeQuery(urlParams, { addQuestionSymbol: true });
+       *     const urlBase = searchValue ? searchUrl : '/';
+       *     const url = urlBase + urlQuery;
+       *     [> console.log('[ProcessesListSearch:doSearch]', {
+       *      *   url,
+       *      *   urlQuery,
+       *      *   urlParams,
+       *      *   urlBase,
+       *      *   searchValue,
+       *      *   searchUrl,
+       *      * });
+       *      <]
+       *     location.assign(url);
+       *   }
+       *   return false;
+       * },
+       */
 
       /** Apply search */
       doSearch() {

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
@@ -23,6 +23,8 @@ modules.define(
     // global module variable
     // eslint-disable-next-line no-unused-vars
     const ProcessesListStates = {
+      __id: 'ProcessesListStates',
+
       setLoading(isLoading) {
         // Set css class for id="processes-list-root" --> loading, set local status
         const rootNode = ProcessesListNodes.getRootNode();
@@ -141,23 +143,23 @@ modules.define(
       },
 
       /** updateDomOrderBy -- Update actual 'order by' dom node.
-       * @param {'random' | 'name' | 'location' | 'product'} [orderByValue]
+       * @param {'random' | 'name' | 'location' | 'product'} [orderBy]
        */
-      updateDomOrderBy(orderByValue) {
+      updateDomOrderBy(orderBy) {
         const { defaultOrderBy } = ProcessesListConstants;
-        const orderBy = orderByValue || defaultOrderBy;
+        const value = orderBy || defaultOrderBy;
         const elems = document.querySelectorAll('input[type="radio"][name="order_by"]');
-        elems.forEach((elem) => (elem.checked = elem.value === orderBy));
+        elems.forEach((elem) => (elem.checked = elem.value === value));
       },
 
       /** updateDomFilterBy -- Update actual 'filter by' dom node.
-       * @param {'random' | 'name' | 'location' | 'product'} [filterByValue]
+       * @param {'random' | 'name' | 'location' | 'product'} [filterBy]
        */
-      updateDomFilterBy(filterByValue) {
+      updateDomFilterBy(filterBy) {
         const { defaultFilterBy } = ProcessesListConstants;
-        const filterBy = filterByValue || defaultFilterBy;
+        const value = filterBy || defaultFilterBy;
         const elems = document.querySelectorAll('input[type="radio"][name="filter_by"]');
-        elems.forEach((elem) => (elem.checked = elem.value === filterBy));
+        elems.forEach((elem) => (elem.checked = elem.value === value));
       },
 
       /** updatePage -- Update all the page dynamic elements

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
@@ -39,6 +39,11 @@ modules.define(
         ProcessesListData.hasData = hasData;
       },
 
+      // setError -- Shorthand for `setHasData`
+      setEmpty(isEmpty) {
+        this.setHasData(!isEmpty);
+      },
+
       getAvailableRecordsContent(availableCount) {
         if (!availableCount || availableCount < 0) {
           return '';
@@ -67,12 +72,6 @@ modules.define(
         rootNode.classList.toggle('has-more-data', hasMoreData);
         ProcessesListData.hasMoreData = hasMoreData;
       },
-
-      /* // UNUSED: setError -- Shorthand for `setHasData`
-       * setEmpty(isEmpty) {
-       *   this.setHasData(false);
-       * },
-       */
 
       setError(error) {
         // TODO: Set css class for id="processes-list-root" --> error, update local state
@@ -115,12 +114,13 @@ modules.define(
         const prevClass = ['order', ProcessesListData.orderBy || defaultOrderBy]
           .filter(Boolean)
           .join('-');
-        const nextClass = ['order', orderBy || defaultOrderBy].filter(Boolean).join('-');
+        const value = orderBy || defaultOrderBy;
+        const nextClass = ['order', value].filter(Boolean).join('-');
         if (prevClass !== nextClass) {
           rootNode.classList.toggle(prevClass, false);
         }
         rootNode.classList.toggle(nextClass, true);
-        ProcessesListData.orderBy = orderBy || defaultOrderBy;
+        ProcessesListData.orderBy = value;
         // Clear current data...
         if (!opts.omitClearData) {
           this.clearData();
@@ -138,12 +138,37 @@ modules.define(
         const prevClass = ['filter', ProcessesListData.filterBy || defaultFilterBy]
           .filter(Boolean)
           .join('-');
-        const nextClass = ['filter', filterBy || defaultFilterBy].filter(Boolean).join('-');
+        const value = filterBy || defaultFilterBy;
+        const nextClass = ['filter', value].filter(Boolean).join('-');
         if (prevClass !== nextClass) {
           rootNode.classList.toggle(prevClass, false);
         }
         rootNode.classList.toggle(nextClass, true);
-        ProcessesListData.filterBy = filterBy || defaultFilterBy;
+        ProcessesListData.filterBy = value;
+        // Clear current data...
+        if (!opts.omitClearData) {
+          this.clearData();
+        }
+      },
+
+      /** setUserDb -- Set 'userDb' parameter.
+       * @param {'matched' | 'unmatched' | 'waitlist'} [userDb]
+       * @param {object} [opts]
+       * @param {boolean} [opts.omitClearData] - Don't clear data.
+       */
+      setUserDb(userDb, opts = {}) {
+        const { defaultUserDb } = ProcessesListConstants;
+        const rootNode = ProcessesListNodes.getRootNode();
+        const prevClass = ['filter', ProcessesListData.userDb || defaultUserDb]
+          .filter(Boolean)
+          .join('-');
+        const value = userDb || defaultUserDb;
+        const nextClass = ['filter', value].filter(Boolean).join('-');
+        if (prevClass !== nextClass) {
+          rootNode.classList.toggle(prevClass, false);
+        }
+        rootNode.classList.toggle(nextClass, true);
+        ProcessesListData.userDb = value;
         // Clear current data...
         if (!opts.omitClearData) {
           this.clearData();
@@ -170,6 +195,16 @@ modules.define(
         elems.forEach((elem) => (elem.checked = elem.value === value));
       },
 
+      /** updateDomUserDb -- Update actual 'userDb' dom node.
+       * @param {'random' | 'name' | 'location' | 'product'} [userDb]
+       */
+      updateDomUserDb(userDb) {
+        const { defaultUserDb } = ProcessesListConstants;
+        const value = userDb || defaultUserDb;
+        const elems = document.querySelectorAll('input[type="radio"][name="user-db"]');
+        elems.forEach((elem) => (elem.checked = elem.value === value));
+      },
+
       /** updatePage -- Update all the page dynamic elements
        */
       updatePage() {
@@ -192,13 +227,29 @@ modules.define(
         });
       },
 
+      initUserDbData() {
+        const { sharedParams } = ProcessesListData;
+        const { databases, database } = sharedParams;
+        if (!databases.proxy) {
+          const proxyDbOption = document.getElementById('user-db-proxy');
+          proxyDbOption.setAttribute('disabled', true);
+          const proxyDbOptionParent = proxyDbOption.parentNode;
+          proxyDbOptionParent.classList.toggle('radio-group-item-disabled', true);
+        }
+      },
+
       start() {
-        // Update parameters...
-        this.updateDomOrderBy();
-        this.updateDomFilterBy();
-        this.setOrderBy();
-        this.setFilterBy();
-        // TODO: Update correspond dom radio groups?
+        // Update all the dynamic parameters...
+        // Order by selector...
+        this.updateDomOrderBy(undefined);
+        this.setOrderBy(undefined, { omitClearData: true });
+        // Filter by selector...
+        this.updateDomFilterBy(undefined);
+        this.setFilterBy(undefined, { omitClearData: true });
+        // Database selector...
+        this.updateDomUserDb(undefined);
+        this.setUserDb(undefined, { omitClearData: true });
+        this.initUserDbData();
       },
     };
 

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
@@ -40,11 +40,19 @@ modules.define(
       },
 
       getAvailableRecordsContent(availableCount) {
-        const { pageSize } = ProcessesListConstants;
-        if (!availableCount) {
+        if (!availableCount || availableCount < 0) {
           return '';
         }
-        return `(next ${pageSize} out of ${availableCount} available)`;
+        const { pageSize } = ProcessesListConstants;
+        const moreThanAPage = pageSize < availableCount;
+        const text = [
+          // prettier-ignore
+          moreThanAPage && pageSize,
+          `${availableCount} available`,
+        ]
+          .filter(Boolean)
+          .join(' out of ');
+        return ` (next ${text})`;
       },
 
       updateAvailableRecordsInfo(availableCount) {

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
@@ -21,7 +21,6 @@ modules.define(
      */
 
     // global module variable
-    // eslint-disable-next-line no-unused-vars
     const ProcessesListStates = {
       __id: 'ProcessesListStates',
 

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
@@ -43,6 +43,17 @@ modules.define(
         // Set css class for root node, update local state
         const rootNode = ProcessesListNodes.getRootNode();
         rootNode.classList.toggle('has-search', hasSearch);
+        ProcessesListData.hasSearch = hasSearch;
+      },
+
+      setTotalRecordsCount(totalRecords) {
+        ProcessesListData.totalRecords = totalRecords;
+        // Set css class for root node, update local state
+        const rootNode = ProcessesListNodes.getRootNode();
+        const elems = rootNode.querySelectorAll('#total-records-number');
+        elems.forEach((node) => {
+          node.innerHTML = String(totalRecords);
+        });
       },
 
       // setError -- Shorthand for `setHasData`

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
@@ -39,6 +39,12 @@ modules.define(
         ProcessesListData.hasData = hasData;
       },
 
+      setHasSearch(hasSearch) {
+        // Set css class for root node, update local state
+        const rootNode = ProcessesListNodes.getRootNode();
+        rootNode.classList.toggle('has-search', hasSearch);
+      },
+
       // setError -- Shorthand for `setHasData`
       setEmpty(isEmpty) {
         this.setHasData(!isEmpty);
@@ -227,18 +233,18 @@ modules.define(
         });
       },
 
-      /* // Issue #41: Disable for obviousity.
-       * initUserDbData() {
-       *   const { sharedParams } = ProcessesListData;
-       *   const { databases } = sharedParams;
-       *   if (!databases.proxy) {
-       *     const proxyDbOption = document.getElementById('user-db-proxy');
-       *     proxyDbOption.setAttribute('disabled', true);
-       *     const proxyDbOptionParent = proxyDbOption.parentNode;
-       *     proxyDbOptionParent.classList.toggle('radio-group-item-disabled', true);
-       *   }
-       * },
+      /* initUserDbData -- Initialize proxy db option
        */
+      initUserDbData() {
+        const { sharedParams } = ProcessesListData;
+        const { databases } = sharedParams;
+        if (!databases.proxy) {
+          const proxyDbOption = document.getElementById('user-db-proxy');
+          proxyDbOption.setAttribute('disabled', true);
+          const proxyDbOptionParent = proxyDbOption.parentNode;
+          proxyDbOptionParent.classList.toggle('radio-group-item-disabled', true);
+        }
+      },
 
       start() {
         // Update all the dynamic parameters...
@@ -251,6 +257,7 @@ modules.define(
         // Database selector...
         this.updateDomUserDb(undefined);
         this.setUserDb(undefined, { omitClearData: true });
+        // Initialize proxy db option
         this.initUserDbData();
       },
     };

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
@@ -227,16 +227,18 @@ modules.define(
         });
       },
 
-      initUserDbData() {
-        const { sharedParams } = ProcessesListData;
-        const { databases, database } = sharedParams;
-        if (!databases.proxy) {
-          const proxyDbOption = document.getElementById('user-db-proxy');
-          proxyDbOption.setAttribute('disabled', true);
-          const proxyDbOptionParent = proxyDbOption.parentNode;
-          proxyDbOptionParent.classList.toggle('radio-group-item-disabled', true);
-        }
-      },
+      /* // Issue #41: Disable for obviousity.
+       * initUserDbData() {
+       *   const { sharedParams } = ProcessesListData;
+       *   const { databases } = sharedParams;
+       *   if (!databases.proxy) {
+       *     const proxyDbOption = document.getElementById('user-db-proxy');
+       *     proxyDbOption.setAttribute('disabled', true);
+       *     const proxyDbOptionParent = proxyDbOption.parentNode;
+       *     proxyDbOptionParent.classList.toggle('radio-group-item-disabled', true);
+       *   }
+       * },
+       */
 
       start() {
         // Update all the dynamic parameters...

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -52,11 +52,6 @@
 
 <script>
   modules.require('CompareCore', (CompareCore) => {
-    /* // Enable debug mode...
-     * const useDebug = true;
-     * // TODO: Expose it to global scope?
-     */
-
     // Global variables for compare tables feature (via global variable `sharedData`)...
     const sharedData = {
       source_data: {{ source_data_json|safe }}, // TDataRecord[]
@@ -67,35 +62,14 @@
       target_name: '{{ target_node.name|safe }}',
       source_node_unit: '{{source_node.unit}}',
       source_node_location: '{{source_node.location}}',
-      // TODO: Remove when #41 is closed
-      // Not used anyway?
-      source_db_label: '{{ source }}',
-      target_db_label: '{{ target }}',
-      proxy_db_label: '{{ proxy }}',
+      /* XXX: Probably these labels should be added in `index.html`? Is it required here?
+       * // TODO: Remove when #41 is closed
+       * // Not used anyway?
+       * source_db_label: '{{ source }}',
+       * target_db_label: '{{ target }}',
+       * proxy_db_label: '{{ proxy }}',
+       */
     };
-
-    /* // DEBUG: Crop data table to easier debugging...
-     * if (useDebug) {
-     *   sharedData.source_data.length = 2;
-     *   sharedData.target_data.length = 2;
-     * }
-     */
-
-    /* // DEBUG: Emulate pre-collapsed elements data...
-     * if (useDebug) {
-     *   // Link first columns...
-     *   const collapsedGroupId = 'Collapsed-0-abcdef'
-     *   sharedData.source_data[0].collapsed = true
-     *   sharedData.source_data[0]['collapsed-group'] = collapsedGroupId;
-     *   sharedData.target_data[0].collapsed = true
-     *   sharedData.target_data[0]['collapsed-group'] = collapsedGroupId;
-     *   console.log('DEBUG: Emulate pre-collapsed elements data', {
-     *     source_data: sharedData.source_data,
-     *     target_data: sharedData.target_data,
-     *   });
-     *   debugger;
-     * }
-     */
 
     // Export to global scope (to access from generated html code handlers).
     window.CompareCore = CompareCore;

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -124,7 +124,7 @@
     const sharedParams = {
       searchUrl: '{{ url_for("search") }}',
       // TODO: Remove this when #41 is closed
-      database: '{{ database }}' // Used only for `searchUrl` requests.
+      database: '{{ database }}', // Used only for `searchUrl` requests.
       databases: {
         source: '{{ source }}',
         target: '{{ target }}',

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -125,7 +125,7 @@
     const sharedParams = {
       searchUrl: '{{ url_for("search") }}',
       // TODO: Remove this when #41 is closed
-      database: '{{ database }}', // Used only for `searchUrl` requests.
+      // database: '{{ database }}', // UNUSED: #41: Using `databases` and `userDb`.
       databases: {
         source: '{{ source }}',
         target: '{{ target }}',

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -78,6 +78,7 @@
       <div id="processes-list-error" class="error">
         <!-- Error text comes here -->
       </div>
+      <div id="processes-list-table-empty" class="processes-list-table-empty">No data loaded for current conditions</div>
       <table id="processes-list-table" class="fixed-table processes-list-table" width="100%">
         <thead>
           <tr>

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -94,7 +94,7 @@
   <div id="processes-list-error" class="error">
     <!-- Error text comes here -->
   </div>
-  <div id="processes-list-table-empty" class="processes-list-table-empty">No data loaded for current conditions</div>
+  <div id="processes-list-table-empty" class="processes-list-table-empty">No data has loaded for current conditions</div>
   <table id="processes-list-table" class="fixed-table processes-list-table" width="100%">
     <thead>
       <tr>
@@ -113,6 +113,7 @@
       <a id="action-reload-random" onClick="ProcessesList.clearAndReloadData(this)">Reload random data</a>
       <a id="action-load-more" onClick="ProcessesList.loadMoreData(this)">Load more<span id="available-records-info"></span></a>
       <a id="action-clear-and-reload" onClick="ProcessesList.clearAndReloadData(this)">Reload</a>
+      <span id="show-total-records-number">Loaded all the available records (<span id="total-records-number"></span>)</span>
     </div>
     <div id="loader-splash" class="loader-splash full-cover"><div class="loader-spinner"></div></div>
   </div>

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -22,85 +22,99 @@
 
 <div id="processes-list-root" class="container processes-list empty loading">
   {% include 'navigation.html' %}
-  <div class="row">
-    <div class="column">
-      <div class="page-search">
-        <p><input type="text" class="u-full-width" placeholder="Enter value to search" value="{{ query_string }}" id="query_string" /></p>
-      </div>
-      <div class="page-filters">
-        <span class="radio-group order-by">
-          {# Controls for `order_by` parameter (name, location, product;
-          default is (empty) i.e. random (see `order-random` for
-          `.processes-list` root node. #}
-          <span class="radio-group-title-wrapper">
-            <label class="radio-group-title">Order by:</label>
-          </span>
-          <span class="radio-group-item">
-            <input type="radio" name="order_by" id="order_by_random" value="random" onChange="ProcessesList.onOrderByChange(this)">
-            <label for="order_by_random">Random</label>
-          </span>
-          <span class="radio-group-item">
-            <input type="radio" name="order_by" id="order_by_name" value="name" onChange="ProcessesList.onOrderByChange(this)">
-            <label for="order_by_name">Name</label>
-          </span>
-          <span class="radio-group-item">
-            <input type="radio" name="order_by" id="order_by_location" value="location" onChange="ProcessesList.onOrderByChange(this)">
-            <label for="order_by_location">Location</label>
-          </span>
-          <span class="radio-group-item">
-            <input type="radio" name="order_by" id="order_by_product" value="product" onChange="ProcessesList.onOrderByChange(this)">
-            <label for="order_by_product">Product</label>
-          </span>
-        </span>
-        <span class="radio-group filter-by">
-          {# Controls for `filter` parameter: `matched`, `unmatched`, or `waitlist`. #}
-          <span class="radio-group-title-wrapper">
-            <label class="radio-group-title">Filter by:</label>
-          </span>
-          <span class="radio-group-item">
-            <input type="radio" name="filter_by" id="filter_by_none" value="none" onChange="ProcessesList.onFilterByChange(this)">
-            <label for="filter_by_none">None</label>
-          </span>
-          <span class="radio-group-item">
-            <input type="radio" name="filter_by" id="filter_by_matched" value="matched" onChange="ProcessesList.onFilterByChange(this)">
-            <label for="filter_by_matched">Matched</label>
-          </span>
-          <span class="radio-group-item">
-            <input type="radio" name="filter_by" id="filter_by_unmatched" value="unmatched" onChange="ProcessesList.onFilterByChange(this)">
-            <label for="filter_by_unmatched">Unmatched</label>
-          </span>
-          <span class="radio-group-item">
-            <input type="radio" name="filter_by" id="filter_by_waitlist" value="waitlist" onChange="ProcessesList.onFilterByChange(this)">
-            <label for="filter_by_waitlist">Waitlist</label>
-          </span>
-        </span>
-      </div>
-      <div id="processes-list-error" class="error">
-        <!-- Error text comes here -->
-      </div>
-      <div id="processes-list-table-empty" class="processes-list-table-empty">No data loaded for current conditions</div>
-      <table id="processes-list-table" class="fixed-table processes-list-table" width="100%">
-        <thead>
-          <tr>
-            <th><div>Name</div></th>
-            <th><div>Location</div></th>
-            <th><div>Unit</div></th>
-            <th><div>Matched</div></th>
-          </tr>
-        </thead>
-        <tbody id="processes-list-table-body">
-          {# NOTE: Content is dynamically populated in client's js code, see `ProcessesListDataRender` #}
-        </tbody>
-      </table>
-      <div class="bottom-actions">
-        <div class="bottom-actions-links">
-          <a id="action-reload-random" onClick="ProcessesList.clearAndReloadData(this)">Reload random data</a>
-          <a id="action-load-more" onClick="ProcessesList.loadMoreData(this)">Load more<span id="available-records-info"></span></a>
-          <a id="action-clear-and-reload" onClick="ProcessesList.clearAndReloadData(this)">Reload</a>
-        </div>
-        <div id="loader-splash" class="loader-splash full-cover"><div class="loader-spinner"></div></div>
-      </div>
+  <div class="page-search">
+    <p><input type="text" class="u-full-width" placeholder="Enter value to search" value="{{ query_string }}" id="query_string" /></p>
+  </div>
+  <div class="page-filters">
+    <span class="radio-group order-by">
+      {# Controls for `order_by` parameter (name, location, product;
+      default is (empty) i.e. random (see `order-random` for
+      `.processes-list` root node. #}
+      <span class="radio-group-title-wrapper">
+        <label class="radio-group-title">Order by:</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="order_by" id="order_by_random" value="random" onChange="ProcessesList.onOrderByChange(this)">
+        <label for="order_by_random">Random</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="order_by" id="order_by_name" value="name" onChange="ProcessesList.onOrderByChange(this)">
+        <label for="order_by_name">Name</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="order_by" id="order_by_location" value="location" onChange="ProcessesList.onOrderByChange(this)">
+        <label for="order_by_location">Location</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="order_by" id="order_by_product" value="product" onChange="ProcessesList.onOrderByChange(this)">
+        <label for="order_by_product">Product</label>
+      </span>
+    </span>
+    <span class="radio-group filter-by">
+      {# Controls for `filter` parameter: `matched`, `unmatched`, or `waitlist`. #}
+      <span class="radio-group-title-wrapper">
+        <label class="radio-group-title">Filter by:</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="filter_by" id="filter_by_none" value="none" onChange="ProcessesList.onFilterByChange(this)">
+        <label for="filter_by_none">None</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="filter_by" id="filter_by_matched" value="matched" onChange="ProcessesList.onFilterByChange(this)">
+        <label for="filter_by_matched">Matched</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="filter_by" id="filter_by_unmatched" value="unmatched" onChange="ProcessesList.onFilterByChange(this)">
+        <label for="filter_by_unmatched">Unmatched</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="filter_by" id="filter_by_waitlist" value="waitlist" onChange="ProcessesList.onFilterByChange(this)">
+        <label for="filter_by_waitlist">Waitlist</label>
+      </span>
+    </span>
+    <span class="radio-group user-db">
+      {# Controls for `database` parameter: `Source`, `Target`, `Proxy`. #}
+      <span class="radio-group-title-wrapper">
+        <label class="radio-group-title">Database:</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="user-db" id="user-db-source" value="source" onChange="ProcessesList.onUserDbChange(this)">
+        <label for="user-db-source">Source</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="user-db" id="user-db-target" value="target" onChange="ProcessesList.onUserDbChange(this)">
+        <label for="user-db-target">Target</label>
+      </span>
+      <span class="radio-group-item">
+        <input type="radio" name="user-db" id="user-db-proxy" value="proxy" onChange="ProcessesList.onUserDbChange(this)">
+        <label for="user-db-proxy">Proxy</label>
+      </span>
+    </span>
+  </div>
+  <div id="processes-list-error" class="error">
+    <!-- Error text comes here -->
+  </div>
+  <div id="processes-list-table-empty" class="processes-list-table-empty">No data loaded for current conditions</div>
+  <table id="processes-list-table" class="fixed-table processes-list-table" width="100%">
+    <thead>
+      <tr>
+        <th><div>Name</div></th>
+        <th><div>Location</div></th>
+        <th><div>Unit</div></th>
+        <th><div>Matched</div></th>
+      </tr>
+    </thead>
+    <tbody id="processes-list-table-body">
+      {# NOTE: Content is dynamically populated in client's js code, see `ProcessesListDataRender` #}
+    </tbody>
+  </table>
+  <div class="bottom-actions">
+    <div class="bottom-actions-links">
+      <a id="action-reload-random" onClick="ProcessesList.clearAndReloadData(this)">Reload random data</a>
+      <a id="action-load-more" onClick="ProcessesList.loadMoreData(this)">Load more<span id="available-records-info"></span></a>
+      <a id="action-clear-and-reload" onClick="ProcessesList.clearAndReloadData(this)">Reload</a>
     </div>
+    <div id="loader-splash" class="loader-splash full-cover"><div class="loader-spinner"></div></div>
   </div>
 </div>
 
@@ -110,10 +124,12 @@
     const sharedParams = {
       searchUrl: '{{ url_for("search") }}',
       // TODO: Remove this when #41 is closed
-      database: '{{ database }}',
-      source_db_label: '{{ source }}',
-      target_db_label: '{{ target }}',
-      proxy_db_label: '{{ proxy }}',
+      database: '{{ database }}' // Used only for `searchUrl` requests.
+      databases: {
+        source: '{{ source }}',
+        target: '{{ target }}',
+        proxy: '{{ proxy or "" }}',
+      },
     };
 
     // Export to global scope (to access from generated html code handlers).

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -58,6 +58,10 @@
             <label class="radio-group-title">Filter by:</label>
           </span>
           <span class="radio-group-item">
+            <input type="radio" name="filter_by" id="filter_by_none" value="none" onChange="ProcessesList.onFilterByChange(this)">
+            <label for="filter_by_none">None</label>
+          </span>
+          <span class="radio-group-item">
             <input type="radio" name="filter_by" id="filter_by_matched" value="matched" onChange="ProcessesList.onFilterByChange(this)">
             <label for="filter_by_matched">Matched</label>
           </span>


### PR DESCRIPTION
- Server-provided parameter `database` not used anymore (using `databases` and `userDb` instead).
- Improved logic of requesting `search` via `/processes` api (disabled usage of `order_by` parameter if `search` is already in use), updated `bottom-actions-links` layout and css styles (added `show-total-records-number` block).
- Using the same dynamic api request (`/processes`) for search feature (search input field).
- Added database selector, added possibility to disable `proxy` db option if no `proxy` value passed from server, refactored page layout (fixed some layout bugs).
- Updated available records info section, added 'no data for these conditions' block.
- Added 'none' filter option (default).
