### PR TITLE
Fixes #52: Match type select box & logic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 # Custom (project-generated files)
 config.toml
 changes.json
+match_types.json

--- a/bw_matchbox/assets/css/common-modal.css
+++ b/bw_matchbox/assets/css/common-modal.css
@@ -12,7 +12,7 @@ body.has-modal {
   /* By default is hidden and inactive, see `show` state below */
   pointer-events: none;
   opacity: 0;
-  transition: all var(--common-effect-time) ease-in-out;
+  transition: all var(--common-effect-time) ease-out;
   /* Emulate show effect */
   margin-top: -100px;
   margin-bottom: 100px;

--- a/bw_matchbox/assets/css/common-modal.css
+++ b/bw_matchbox/assets/css/common-modal.css
@@ -12,7 +12,7 @@ body.has-modal {
   /* By default is hidden and inactive, see `show` state below */
   pointer-events: none;
   opacity: 0;
-  transition: all var(--common-animation-time);
+  transition: all var(--common-effect-time) ease-in-out;
   /* Emulate show effect */
   margin-top: -100px;
   margin-bottom: 100px;

--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -8,6 +8,7 @@
   --layout-theme-error-color: #c33;
   /* Animations */
   --common-animation-time: 250ms;
+  --common-effect-time: 500ms;
 }
 
 /* Basic layout */

--- a/bw_matchbox/assets/css/compare.css
+++ b/bw_matchbox/assets/css/compare.css
@@ -122,41 +122,46 @@
 }
 
 /* Modal customizations for `set-number-modal`: inner layout with inner scrolls */
-.common-modal-content#set-number-modal .common-modal-content-wrapper {
+#set-number-modal .common-modal-content-wrapper {
   /* Made wrapper clipping */
   display: flex;
 }
-.common-modal-content#set-number-modal .common-modal-content-wrapper > div {
+#set-number-modal .common-modal-content-wrapper > div {
   /* Both inner columns are scrollable */
   overflow: auto;
   padding: 20px;
   flex: 1;
   width: 50%;
 }
-.common-modal-content#set-number-modal .common-modal-content-wrapper > div > *:last-child {
+#set-number-modal .common-modal-content-wrapper > div > *:last-child {
   margin-bottom: 0;
 }
 
 /* Adjust 'edit number' modal table columns widths */
-.common-modal-content#set-number-modal #edit-number-table th:last-child {
+#set-number-modal #edit-number-table th:last-child {
   width: 50px;
 }
-.common-modal-content#set-number-modal #edit-number-table th:first-child {
+#set-number-modal #edit-number-table th:first-child {
   width: 80px;
 }
 /* Adjust 'edit number' modal content styles */
-.common-modal-content#set-number-modal .strong {
+#set-number-modal .strong {
   margin: 5px 0;
 }
 
 /* Adjust 'proxy-dialog-modal' modal content styles */
-.common-modal-content#proxy-dialog-modal #proxy-table th:first-child {
+#proxy-dialog-modal #proxy-table th:first-child {
   width: 50%;
 }
-.common-modal-content#proxy-dialog-modal #proxy-table th:nth-child(2) {
+#proxy-dialog-modal #proxy-table th:nth-child(2) {
   width: 7em;
 }
-.common-modal-content#proxy-dialog-modal #proxy-table td:last-child div textarea {
+#proxy-dialog-modal #proxy-table td:last-child div textarea {
   display: block;
   width: 100%;
+}
+#proxy-dialog-modal #match-type-select {
+  max-width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/bw_matchbox/assets/js/Compare/CompareCore.js
+++ b/bw_matchbox/assets/js/Compare/CompareCore.js
@@ -19,21 +19,6 @@ modules.define(
   ) {
     /* Compare tables feature code (via global variable `CompareCore`).
      *
-     * Mouse handler methods are used:
-     * - CompareRowsHelpers.clickRowHandler -- Click on regular row to select or collapse selected rows.
-     * - CompareRowsHelpers.clickUncollapseRowHandler -- Click on collapsed row handler to uncollapse.
-     * - CompareRowClick.disableRowClickHandler -- To disable row click effect (if we have some nested interactive elements).
-     * - CompareCore.removeRowHandler
-     * - CompareCore.expandRowHandler
-     * - CompareCore.editNumberHandler
-     * - CompareCore.shiftRowHandler
-     * - CompareCore.replaceAmountRowHandler
-     * - CompareCore.setNumberHandler
-     * - CompareCore.setNewNumberHandler
-     * - CompareCore.resetNumberHandler
-     * - CompareCore.rescaleAmountHandler
-     * - CompareCore.replaceWithTargetHandler
-     *
      * Data table record types:
      *
      * interface TDataRecord {
@@ -57,10 +42,6 @@ modules.define(
 
       // Counter for making unique records (see `replaceWithTargetHandler`)
       targetNodesCounter: 0,
-
-      /* // UNUSED: Local data: construct comment field for the `set-number-modal` modal dialog...
-       * comment: '',
-       */
 
       // Methods...
 
@@ -101,11 +82,6 @@ modules.define(
           const otherTableDataKey = otherRowKind + '_data';
           const otherTableData = this.sharedData[otherTableDataKey];
           const collapsedGroupId = data['collapsed-group'];
-          /* // ORIGONAL BUG: Don't use indices as row_id's!
-           * const otherRowId = otherTableData.findIndex(
-           *   (other) => other['collapsed-group'] === collapsedGroupId,
-           * );
-           */
           const otherRowData = otherTableData.find(
             (other) => other['collapsed-group'] === collapsedGroupId,
           );
@@ -113,15 +89,6 @@ modules.define(
             throw new Error('Cannot find other collapsed record');
           }
           const otherRowId = otherRowData.row_id;
-          /* console.log('[CompareCore:buildRow] check', {
-           *   otherRowId,
-           *   otherRowKind,
-           *   otherTableDataKey,
-           *   otherTableData,
-           *   collapsedGroupId,
-           *   otherRowData,
-           * });
-           */
           const otherCollapsedId = CompareRowsHelpers.getCollapsedId(otherRowKind, otherRowId);
           collapsedRows[collapsedId] = {
             rowKind,

--- a/bw_matchbox/assets/js/Compare/CompareProxyDialogModal.js
+++ b/bw_matchbox/assets/js/Compare/CompareProxyDialogModal.js
@@ -1,0 +1,240 @@
+modules.define(
+  'CompareProxyDialogModal',
+  [
+    // Required modules...
+    // 'CommonHelpers',
+    'CommonModal',
+    // 'CompareRowClick',
+    // 'CompareRowsHelpers',
+  ],
+  function provide_CompareProxyDialogModal(
+    provide,
+    // Resolved modules...
+    // CommonHelpers,
+    CommonModal,
+    // CompareRowClick,
+    // CompareRowsHelpers,
+  ) {
+    // Define module...
+    const CompareProxyDialogModal = {
+      // External data...
+      sharedData: undefined, // Initializing in `CompareCore.start` from `bw_matchbox/assets/templates/compare.html`
+
+      // Counter for making unique records (see `replaceWithTargetHandler`)
+      targetNodesCounter: 0,
+
+      // Match type...
+      selectedMatchType: undefined,
+
+      /* // UNUSED: Local data: construct comment field for the `set-number-modal` modal dialog...
+       * comment: '',
+       */
+
+      // Methods...
+
+      getTargetProxyName() {
+        const { target_name } = this.sharedData;
+        const name =
+          'Proxy for ' +
+          target_name
+            .replace('Market group for ', '')
+            .replace('market group for ', '')
+            .replace('Market for ', '')
+            .replace('market for ', '')
+            .trim();
+        return name;
+      },
+
+      createOneToOneProxyFunc(event) {
+        event.preventDefault();
+
+        const submissionData = {
+          exchanges: [{ input_id: this.sharedData.target_id, amount: 1.0 }],
+          source: this.sharedData.source_id,
+          comment: 'One-to-one proxy',
+          name: this.getTargetProxyName(),
+          /* // ORIGINAL CODE
+           * name:
+           *   'Proxy for ' +
+           *   this.sharedData.target_name
+           *     .replace('Market group for ', '')
+           *     .replace('market group for ', '')
+           *     .replace('Market for ', '')
+           *     .replace('market for ', '')
+           *     .trim(),
+           */
+        };
+        const url = '/create-proxy/';
+        fetch(url, {
+          method: 'POST',
+          redirect: 'follow',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(submissionData),
+        }).then((response) => {
+          if (response.redirected) {
+            window.location.href = response.url;
+          }
+        });
+      },
+
+      getSelectedMatchType() {
+        const { selectedMatchType } = this;
+        const { match_type_default } = this.sharedData;
+        return selectedMatchType === undefined ? match_type_default : selectedMatchType;
+      },
+
+      /** renderProxyModalContent -- Generate proxy modal content
+       * @return {string}
+       */
+      renderProxyModalContent() {
+        const {
+          source_node_unit,
+          source_node_location,
+          target_data,
+          match_types,
+          // match_type_default,
+          comment,
+        } = this.sharedData;
+        const selectedMatchType = this.getSelectedMatchType();
+
+        const name = this.getTargetProxyName();
+        /* // ORIGINAL CODE
+         * const name =
+         *   'Proxy for ' +
+         *   target_name
+         *     .replace('Market group for ', '')
+         *     .replace('market group for ', '')
+         *     .replace('Market for ', '')
+         *     .replace('market for ', '')
+         *     .trim();
+         */
+
+        const matchModalItems = Object.entries(match_types).map(([id, text]) => {
+          const isSelected = id === selectedMatchType;
+          // const plus = isSelected ? ' selected' : '';
+          return `<option value="${id}"${isSelected && ' selected'}>${text}</option>`;
+        });
+        const matchModalSelect = `
+          <select id="match-type-select">
+            ${matchModalItems.join('\n')}
+          </select>
+        `;
+        console.log('[CompareProxyDialogModal:renderProxyModalContent]: matchModalSelect', {
+          matchModalItems,
+          matchModalSelect,
+        });
+
+        const begin = `
+          <form>
+            <input class="u-full-width" type="text" id="proxy-name" name="proxy-name" value="${name}">
+            <label for="proxy-comment">Comment</label>
+            <textarea class="u-full-width" id="proxy-comment" name="proxy-comment">${comment}</textarea>
+            <p><button class="button-primary" id="create-proxy-submit-button">Create Proxy Process</button>
+            ${matchModalSelect}
+            | Unit: ${source_node_unit}
+            | Location: ${source_node_location}</p>
+            <table id="proxy-table" class="fixed-table" width="100%">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Amount</th>
+                  <th>Comment</th>
+                </tr>
+              </thead>
+              <tbody>
+        `;
+
+        const rows = target_data.map(function (item, _index) {
+          return `
+              <tr input_id=${item.input_id}>
+                <td><div>${item.name}</div></td>
+                <td><div>${item.amount_display}</div></td>
+                <td><div><textarea type="text" id="proxy-name-${item.input_id}" name="proxy-name-${item.input_id}"></textarea></div></td>
+              </tr>
+          `;
+        });
+
+        const end = `
+              </tbody>
+            </table>
+          </form>
+        `;
+
+        const content = begin + rows.join('') + end;
+
+        return content;
+      },
+
+      onSubmitButtonClick(event) {
+        event.preventDefault();
+        const { target_data, source_id } = this.sharedData;
+        const match_type = this.getSelectedMatchType(); // document.getElementById('match-type-select').value;
+        const comment = document.getElementById('proxy-comment').value;
+        const name = document.getElementById('proxy-name').value;
+        const submissionData = {
+          exchanges: target_data,
+          source: source_id,
+          match_type,
+          comment,
+          name,
+        };
+        const url = '/create-proxy/';
+        console.log('[CompareProxyDialogModal:onSubmitButtonClick]', {
+          target_data,
+          source_id,
+          match_type,
+          comment,
+          name,
+          submissionData,
+        });
+        debugger;
+        fetch(url, {
+          method: 'POST',
+          redirect: 'follow',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(submissionData),
+        }).then((response) => {
+          if (response.redirected) {
+            window.location.href = response.url;
+          }
+        });
+      },
+
+      onMatchTypeSelectChange(event) {
+        const { target } = event;
+        console.log('[CompareProxyDialogModal:onMatchTypeSelectChange]', {
+          target,
+          arguments,
+          event,
+        });
+        debugger;
+      },
+
+      openProxyDialogModal(event) {
+        event.preventDefault();
+
+        const content = this.renderProxyModalContent();
+
+        const title = 'Proxy name';
+
+        CommonModal.setModalContentId('proxy-dialog-modal')
+          .setTitle(title)
+          .setModalContentOptions({
+            scrollable: true,
+            padded: true,
+          })
+          .setContent(content)
+          .showModal();
+
+        const submit = document.getElementById('create-proxy-submit-button');
+        submit.addEventListener('click', this.onSubmitButtonClick.bind(this));
+
+        const matchTypeSelect = document.getElementById('match-type-select');
+        matchTypeSelect.addEventListener('change', this.onMatchTypeSelectChange.binf(this));
+      },
+    };
+
+    // Provide module...
+    provide(CompareProxyDialogModal);
+  },
+);

--- a/bw_matchbox/assets/js/Compare/CompareProxyDialogModal.js
+++ b/bw_matchbox/assets/js/Compare/CompareProxyDialogModal.js
@@ -2,18 +2,12 @@ modules.define(
   'CompareProxyDialogModal',
   [
     // Required modules...
-    // 'CommonHelpers',
     'CommonModal',
-    // 'CompareRowClick',
-    // 'CompareRowsHelpers',
   ],
   function provide_CompareProxyDialogModal(
     provide,
     // Resolved modules...
-    // CommonHelpers,
     CommonModal,
-    // CompareRowClick,
-    // CompareRowsHelpers,
   ) {
     // Define module...
     const CompareProxyDialogModal = {
@@ -25,10 +19,6 @@ modules.define(
 
       // Match type...
       selectedMatchType: undefined,
-
-      /* // UNUSED: Local data: construct comment field for the `set-number-modal` modal dialog...
-       * comment: '',
-       */
 
       // Methods...
 
@@ -53,16 +43,6 @@ modules.define(
           source: this.sharedData.source_id,
           comment: 'One-to-one proxy',
           name: this.getTargetProxyName(),
-          /* // ORIGINAL CODE
-           * name:
-           *   'Proxy for ' +
-           *   this.sharedData.target_name
-           *     .replace('Market group for ', '')
-           *     .replace('market group for ', '')
-           *     .replace('Market for ', '')
-           *     .replace('market for ', '')
-           *     .trim(),
-           */
         };
         const url = '/create-proxy/';
         fetch(url, {
@@ -87,42 +67,21 @@ modules.define(
        * @return {string}
        */
       renderProxyModalContent() {
-        const {
-          source_node_unit,
-          source_node_location,
-          target_data,
-          match_types,
-          // match_type_default,
-          comment,
-        } = this.sharedData;
+        const { source_node_unit, source_node_location, target_data, match_types, comment } =
+          this.sharedData;
         const selectedMatchType = this.getSelectedMatchType();
 
         const name = this.getTargetProxyName();
-        /* // ORIGINAL CODE
-         * const name =
-         *   'Proxy for ' +
-         *   target_name
-         *     .replace('Market group for ', '')
-         *     .replace('market group for ', '')
-         *     .replace('Market for ', '')
-         *     .replace('market for ', '')
-         *     .trim();
-         */
 
         const matchModalItems = Object.entries(match_types).map(([id, text]) => {
           const isSelected = id === selectedMatchType;
-          // const plus = isSelected ? ' selected' : '';
-          return `<option value="${id}"${isSelected && ' selected'}>${text}</option>`;
+          return `<option value="${id}"${isSelected ? ' selected' : ''}>${text}</option>`;
         });
         const matchModalSelect = `
           <select id="match-type-select">
             ${matchModalItems.join('\n')}
           </select>
         `;
-        console.log('[CompareProxyDialogModal:renderProxyModalContent]: matchModalSelect', {
-          matchModalItems,
-          matchModalSelect,
-        });
 
         const begin = `
           <form>
@@ -131,7 +90,7 @@ modules.define(
             <textarea class="u-full-width" id="proxy-comment" name="proxy-comment">${comment}</textarea>
             <p><button class="button-primary" id="create-proxy-submit-button">Create Proxy Process</button>
             ${matchModalSelect}
-            | Unit: ${source_node_unit}
+            Unit: ${source_node_unit}
             | Location: ${source_node_location}</p>
             <table id="proxy-table" class="fixed-table" width="100%">
               <thead>
@@ -187,7 +146,6 @@ modules.define(
           name,
           submissionData,
         });
-        debugger;
         fetch(url, {
           method: 'POST',
           redirect: 'follow',
@@ -202,12 +160,8 @@ modules.define(
 
       onMatchTypeSelectChange(event) {
         const { target } = event;
-        console.log('[CompareProxyDialogModal:onMatchTypeSelectChange]', {
-          target,
-          arguments,
-          event,
-        });
-        debugger;
+        const { value } = target;
+        this.selectedMatchType = value;
       },
 
       openProxyDialogModal(event) {
@@ -230,7 +184,7 @@ modules.define(
         submit.addEventListener('click', this.onSubmitButtonClick.bind(this));
 
         const matchTypeSelect = document.getElementById('match-type-select');
-        matchTypeSelect.addEventListener('change', this.onMatchTypeSelectChange.binf(this));
+        matchTypeSelect.addEventListener('change', this.onMatchTypeSelectChange.bind(this));
       },
     };
 

--- a/bw_matchbox/assets/js/Compare/CompareRowsHelpers.js
+++ b/bw_matchbox/assets/js/Compare/CompareRowsHelpers.js
@@ -26,10 +26,11 @@ modules.define(
      */
 
     // Define module...
-
     const CompareRowsHelpers = {
+      // Shared Data...
+      sharedData: undefined, // Initializing in `CompareCore.start` from `bw_matchbox/assets/templates/compare.html`
+
       // Data...
-      sharedData: undefined, // Initializing in `CompareCore.initCompare` from `bw_matchbox/assets/templates/compare.html`
       rowColumnsCount: 5, // Number of columns in a table row (ATTENTION: It could be changed)...
       selectedFirst: undefined, // <undefined | TSelectedRow>
       collapsedRows: {}, // Record<TRowId, TCollapsedRow> -- Hash of collapsed row

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -66,6 +66,17 @@
       source_node_location: '{{source_node.location}}',
       match_types: {{ match_types|safe }},
       match_type_default: "3",
+      /* // #52: match_types sample:
+       * {
+       *   '1': 'No direct match available',
+       *   '2': 'Direct match with near-identical data',
+       *   '3': 'Match with updated data',
+       *   '4': 'Match with updated data and adding source transport',
+       *   '5': 'Match with market and replace or remove transport',
+       *   '6': 'Match with market and replace or remove transport and loss factor',
+       *   '7': 'Equivalent datasets after modification',
+       * }
+       */
     };
 
     // Export to global scope (to access from generated html code handlers).

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/compare.css') }}">
 
 <script src="{{ url_for('static', filename='js/Compare/CompareRowsHelpers.js') }}"></script>
+<script src="{{ url_for('static', filename='js/Compare/CompareProxyDialogModal.js') }}"></script>
 <script src="{{ url_for('static', filename='js/Compare/CompareRowClick.js') }}"></script>
 <script src="{{ url_for('static', filename='js/Compare/CompareCore.js') }}"></script>
 
@@ -65,7 +66,8 @@
       source_node_unit: '{{source_node.unit}}',
       source_node_location: '{{source_node.location}}',
       match_types: {{ match_types|safe }},
-      match_type_default: "3",
+      match_type_default: '3',
+      comment: '', // Shared comments accumulator
       /* // #52: match_types sample:
        * {
        *   '1': 'No direct match available',


### PR DESCRIPTION
Extracted proxy modal code to it's dedicated module (`Compare/CompareProxyDialogModal.js`), moved `comment` field to `sharedData`, added `match-type-select` select input element. Match type value stored in the code, fixed some errors, removed unused code (some debug outputs still remain).