### PR TITLE
Fixes #56: Highlight rows on the 'match' page.

### DIFF
--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -88,3 +88,27 @@
     transform: rotate(360deg);
   }
 }
+
+/* Multicolumn process detail list */
+.details-list {
+  column-gap: 20px;
+  column-rule: 1px solid #eee;
+  column-width: 300px;
+  list-style-type: none;
+  line-height: 1.25;
+}
+.details-list li {
+  margin: 5px 0;
+}
+/* // UNUSED? Using the same width on the all scren widths?
+ * @media (width >= 1300px) {
+ *   .details-list {
+ *     column-width: 350px;
+ *   }
+ * }
+ */
+.details-list label {
+  display: inline;
+  opacity: 0.5;
+  font-weight: normal;
+}

--- a/bw_matchbox/assets/css/match.css
+++ b/bw_matchbox/assets/css/match.css
@@ -1,0 +1,102 @@
+/* stylelint-disable selector-class-pattern */
+
+:root {
+  --match-similar-bg-color05: rgb(30 174 219 / 5%);
+  --match-similar-bg-color10: rgb(30 174 219 / 10%);
+  --match-similar-bg-color15: rgb(30 174 219 / 15%);
+  --match-similar-bg-color20: rgb(30 174 219 / 20%);
+  --match-similar-bg-color30: rgb(30 174 219 / 30%);
+  --match-similar-bg-color40: rgb(30 174 219 / 40%);
+  --match-similar-bg-color50: rgb(30 174 219 / 50%);
+  --match-similar-animation-time: 3s;
+}
+
+/* Basic styles */
+.match-root {
+  /* Animation... */
+  transition: all var(--common-animation-time);
+  position: relative;
+}
+
+.match-root.loading #result-table {
+  display: none;
+}
+
+/* Data table... */
+#result-table {
+  margin-top: 2.5rem;
+}
+/* #result-table th.cell-name { width: 40%; } */
+#result-table th.cell-referenceProduct {
+  width: 10rem;
+}
+#result-table th.cell-location {
+  width: 12rem;
+  white-space: nowrap;
+}
+#result-table th.cell-unit {
+  width: 8rem;
+  white-space: nowrap;
+}
+/* General cells... */
+#result-table td {
+  /* padding: 4px; */
+}
+#result-table td div {
+  /* padding: 4px; */
+}
+/* Similar cells... */
+#result-table td.similar {
+  /* border: 1px solid var(--layout-theme-primary-color); */
+  background: var(--match-similar-bg-color05);
+  background: repeating-linear-gradient(
+    45deg,
+    var(--match-similar-bg-color10),
+    var(--match-similar-bg-color10) 10px,
+    var(--match-similar-bg-color05) 10px,
+    var(--match-similar-bg-color05) 20px
+  );
+  border: 1px solid var(--match-similar-bg-color20);
+  box-shadow: inset 0 0 5px var(--match-similar-bg-color20);
+}
+
+/* Info section */
+.match-root .info-tableau {
+  position: relative;
+  /* margin: 10px 0; */
+  transition: all var(--common-animation-time);
+  min-height: 0;
+}
+.match-root.loading .info-tableau {
+  min-height: 50px;
+}
+
+/* Error */
+.match-root .info-tableau .error {
+  border-radius: 4px;
+  background-color: var(--layout-theme-error-color);
+  color: #fff;
+  margin: 20px auto;
+  padding: 10px 20px;
+}
+.match-root:not(.has-error) .info-tableau .error {
+  display: none;
+}
+
+/* Loader splash */
+.match-root .info-tableau .loader-splash {
+  padding: 20px;
+}
+.match-root:not(.loading) .info-tableau .loader-splash {
+  /* Inherited from `.loader-splash.hidden`, see `bw_matchbox/assets/css/common.css` */
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Disabled buttons */
+.match-root button.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: default;
+  user-select: none;
+}

--- a/bw_matchbox/assets/css/process-detail.css
+++ b/bw_matchbox/assets/css/process-detail.css
@@ -5,36 +5,6 @@
   position: relative;
 }
 
-/* Multicolumn process detail list */
-.process-detail .details-list {
-  column-gap: 20px;
-  column-rule: 1px solid #eee;
-  column-width: 300px;
-  list-style-type: none;
-  line-height: 1.25;
-}
-/* // UNUSED? Using the same width on the all scren widths?
- * @media (width >= 1300px) {
- *   .process-detail .details-list {
- *     column-width: 350px;
- *   }
- * }
- */
-.process-detail .details-list label {
-  display: inline;
-  opacity: 0.5;
-  font-weight: normal;
-}
-
-/* Loading status: disable some elements... */
-.process-detail {
-  /* pointer-events: none; */
-}
-.process-detail.loading {
-  /* opacity: 0.5; */
-  /* pointer-events: none; */
-}
-
 /* Info section */
 .process-detail .info-tableau {
   position: relative;
@@ -61,7 +31,6 @@
 /* Loader splash */
 .process-detail .info-tableau .loader-splash {
   padding: 20px;
-  /* position: fixed; */
 }
 .process-detail:not(.loading) .info-tableau .loader-splash {
   /* Inherited from `.loader-splash.hidden`, see `bw_matchbox/assets/css/common.css` */

--- a/bw_matchbox/assets/js/Compare/CompareProxyDialogModal.js
+++ b/bw_matchbox/assets/js/Compare/CompareProxyDialogModal.js
@@ -43,7 +43,7 @@ modules.define(
           source: this.sharedData.source_id,
           comment: 'One-to-one proxy',
           name: this.getTargetProxyName(),
-          match_type: "2",
+          match_type: '2',
         };
         const url = '/create-proxy/';
         fetch(url, {

--- a/bw_matchbox/assets/js/Match/Match.js
+++ b/bw_matchbox/assets/js/Match/Match.js
@@ -1,0 +1,253 @@
+modules.define(
+  'Match',
+  [
+    // Required modules...
+    'CommonHelpers',
+  ],
+  function provide_Match(
+    provide,
+    // Resolved modules...
+    CommonHelpers,
+  ) {
+    // Define module...
+    const Match = {
+      // External data...
+      sharedData: undefined, // Initializing in `Match.start` from `bw_matchbox/assets/templates/process_detail.html`
+
+      // Local data...
+      defaultMakeUrlParams: { addQuestionSymbol: true, useEmptyStrings: true },
+      searchValue: '',
+
+      // Methods...
+
+      setLoading(isLoading) {
+        const rootEl = document.getElementById('match-root');
+        rootEl.classList.toggle('loading', !!isLoading);
+      },
+
+      /** setError -- Set and show error.
+       * @param {string|error|string[]|error[]} error - Error or errors list.
+       */
+      setError(error) {
+        const hasErrors = !!error;
+        const rootEl = document.getElementById('match-root');
+        rootEl.classList.toggle('has-error', hasErrors);
+        // Show error...
+        const text = CommonHelpers.getErrorText(error);
+        const errorEl = document.getElementById('error');
+        errorEl.innerHTML = text;
+      },
+
+      clearError() {
+        this.setError(undefined);
+      },
+
+      isTableCellValueSimilarToOriginal(cellData) {
+        const { id, value } = cellData;
+        const { sharedData } = this;
+        const { originalProcess } = sharedData;
+        const origValue = originalProcess[id];
+        const cmpValue = (value || '').toLowerCase();
+        const cmpOrigValue = (origValue || '').toLowerCase();
+        // TODO: To use more sophisticated logic?
+        return !!cmpValue && cmpValue === cmpOrigValue;
+      },
+
+      /* makeTableCell
+       * @param {object} cellData
+       * @param {string} cellData.id
+       * @param {string} [cellData.value]
+       * @param {string} [cellData.text]
+       * return {string}
+       */
+      makeTableCell(cellData) {
+        const { id, value, text } = cellData;
+        const isSimilar = this.isTableCellValueSimilarToOriginal(cellData);
+        const content = text || value || '';
+        const className = [`cell-${id}`, isSimilar && 'similar'].filter(Boolean).join(' ');
+        return `
+          <td class="${className}"><div>${content}</div></td>
+        `;
+      },
+
+      renderTableRowsContent(tableRows) {
+        const { sharedData } = this;
+        const {
+          // prettier-ignore
+          source,
+          // searchUrlPrefix,
+          // database,
+        } = sharedData;
+        /* console.log('[Match:renderTableRowsContent]', {
+         *   tableRows,
+         *   source,
+         *   // searchUrlPrefix,
+         *   // database,
+         * });
+         */
+        const content = tableRows
+          .map((rowData) => {
+            const {
+              // On client, we need only this data: id, name, referenceProduct, location, unit
+              id,
+              name,
+              referenceProduct,
+              location,
+              unit,
+            } = rowData;
+            const url = ['/compare', source, id].join('/');
+            const cells = [
+              { id: 'name', value: name, text: `<a href="${url}">${name || ''}</a>` },
+              { id: 'referenceProduct', value: referenceProduct },
+              { id: 'location', value: location },
+              { id: 'unit', value: unit },
+            ];
+            const cellsContent = cells.map(this.makeTableCell.bind(this)).join('');
+            /* console.log('[Match:renderTableRowsContent] iteration', {
+             *   cellsContent,
+             *   cells,
+             *   url,
+             *   id,
+             *   name,
+             *   referenceProduct,
+             *   location,
+             *   unit,
+             *   rowData,
+             * });
+             */
+            return `
+              <tr data-row-id="${id}">
+                ${cellsContent}
+              </tr>
+            `;
+            /* // Original tempate code:
+             * <td class="cell-name"><a href="${url}">${name || ''}</a></td>
+             * <td class="cell-referenceProduct>${referenceProduct || ''}</td>
+             * <td class="cell-location">${location || ''}</td>
+             * <td class="cell-unit">${unit || ''}</td>
+             */
+          })
+          .filter(Boolean)
+          .join('');
+        return content;
+      },
+
+      updateTableRows(tableRows) {
+        const tableBody = document.getElementById('result-table-body');
+        const tableRowsContent = this.renderTableRowsContent(tableRows);
+        /* console.log('[Match:doSearch]: done', {
+         *   tableRowsContent,
+         *   tableBody,
+         *   tableRows,
+         * });
+         */
+        tableBody.innerHTML = tableRowsContent;
+      },
+
+      doSearch() {
+        const { sharedData, defaultMakeUrlParams } = this;
+        const searchBar = document.getElementById('query-string');
+        const {
+          // prettier-ignore
+          searchUrlPrefix,
+          source,
+          database,
+        } = sharedData;
+        const value = searchBar.value;
+        // Do nothing if search string hasn't changed...
+        if (value === this.searchValue) {
+          return;
+        }
+        this.searchValue = value;
+        const params = {
+          json: 1,
+          source,
+          database,
+          q: value,
+        };
+        const urlQuery = CommonHelpers.makeQuery(params, defaultMakeUrlParams);
+        const url = searchUrlPrefix + urlQuery;
+        /* console.log('[Match:doSearch]: start', {
+         *   value,
+         *   urlQuery,
+         *   url,
+         *   searchUrlPrefix,
+         *   source,
+         *   database,
+         * });
+         */
+        this.setLoading(true);
+        fetch(url)
+          .then((res) => {
+            // TODO: if (!res.ok) ...
+            if (!res.ok) {
+              const error = new Error(
+                `Can't load url '${res.url}': ${res.statusText}, ${res.status}`,
+              );
+              throw error;
+            } else {
+              // return res.text();
+              return res.json();
+            }
+          })
+          .then((tableRows) => {
+            /* console.log('[Match:doSearch]: success', {
+             *   tableRows,
+             * });
+             */
+            this.updateTableRows(tableRows);
+            this.setError(undefined);
+          })
+          .catch((error) => {
+            // eslint-disable-next-line no-console
+            console.error('[Match:doSearch] Catched error', error);
+            // eslint-disable-next-line no-debugger
+            debugger;
+            // Show errors on the page...
+            this.setError(error);
+          })
+          .finally(() => {
+            this.setLoading(false);
+          });
+        /* // ORIGINAL CODE
+         * req.addEventListener('load', searchResultUpdater);
+         * req.open('GET', `{{ url_for('search') }}?e=1&source={{ ds.id }}&database={{ target }}&q=' + qs);
+         * req.send();
+         */
+      },
+
+      initSearchBar() {
+        const searchBar = document.getElementById('query-string');
+        // searchBar.focus();
+        searchBar.addEventListener('focusout', this.doSearch.bind(this));
+        searchBar.addEventListener('keypress', (event) => {
+          if (event.key === 'Enter') {
+            this.doSearch();
+          }
+        });
+      },
+
+      start(sharedData) {
+        // Save public data...
+        this.sharedData = sharedData;
+
+        const {
+          // searchUrlPrefix,
+          // source,
+          // database,
+          initialQueryString,
+          initialTableRows,
+        } = sharedData;
+
+        this.searchValue = initialQueryString || '';
+        this.updateTableRows(initialTableRows);
+
+        // Init search bar...
+        this.initSearchBar();
+      },
+    };
+
+    // Provide module...
+    provide(Match);
+  },
+);

--- a/bw_matchbox/assets/js/ProcessDetail/ProcessDetail.js
+++ b/bw_matchbox/assets/js/ProcessDetail/ProcessDetail.js
@@ -157,13 +157,14 @@ modules.define(
         ].filter(Boolean);
         // Call both requests at once...
         const callbacks = urls.map((url) => () => fetch(url));
-        // DEBUG: While #57 is in progress or in testing...
-        console.log('[ProcessDetail:doMarkWaitlist]', {
-          setWaitlist,
-          urls,
-          callbacks,
-          userAction,
-        });
+        /* // DEBUG: While #57 is in progress or in testing...
+         * console.log('[ProcessDetail:doMarkWaitlist]', {
+         *   setWaitlist,
+         *   urls,
+         *   callbacks,
+         *   userAction,
+         * });
+         */
         this.setLoading(true);
         // Run callbacks one by one...
         return CommonHelpers.runAsyncCallbacksSequentially(callbacks)
@@ -212,11 +213,12 @@ modules.define(
         const { sharedData } = this;
         const urls = [sharedData.markMatchedUrl, sharedData.markMatchTypeUrl];
         const callbacks = urls.map((url) => () => fetch(url));
-        // DEBUG: While #57 is in progress or in testing...
-        console.log('[ProcessDetail:markMatched]', {
-          urls,
-          callbacks,
-        });
+        /* // DEBUG: While #57 is in progress or in testing...
+         * console.log('[ProcessDetail:markMatched]', {
+         *   urls,
+         *   callbacks,
+         * });
+         */
         this.setLoading(true);
         // Run callbacks one by one...
         return CommonHelpers.runAsyncCallbacksSequentially(callbacks)

--- a/bw_matchbox/assets/templates/common-modal.html
+++ b/bw_matchbox/assets/templates/common-modal.html
@@ -1,12 +1,3 @@
-{#
-
-NOTE: You need to include nexde if you want to use common modal feature on the page:
-```
-{% include 'common-modal.html' %}
-```
-
-#}
-
 <link rel="stylesheet" href="{{ url_for('static', filename='css/common-modal.css') }}">
 <script src="{{ url_for('static', filename='js/common/CommonModal.js') }}"></script>
 

--- a/bw_matchbox/assets/templates/common-modal.html
+++ b/bw_matchbox/assets/templates/common-modal.html
@@ -1,3 +1,12 @@
+{#
+
+NOTE: You need to include nexde if you want to use common modal feature on the page:
+```
+{% include 'common-modal.html' %}
+```
+
+#}
+
 <link rel="stylesheet" href="{{ url_for('static', filename='css/common-modal.css') }}">
 <script src="{{ url_for('static', filename='js/common/CommonModal.js') }}"></script>
 

--- a/bw_matchbox/assets/templates/common-modal.md
+++ b/bw_matchbox/assets/templates/common-modal.md
@@ -1,4 +1,5 @@
 NOTE: You need to include next code if you want to use common modal feature on the page:
+
 ```
 {% include 'common-modal.html' %}
 ```

--- a/bw_matchbox/assets/templates/common-modal.md
+++ b/bw_matchbox/assets/templates/common-modal.md
@@ -1,0 +1,4 @@
+NOTE: You need to include next code if you want to use common modal feature on the page:
+```
+{% include 'common-modal.html' %}
+```

--- a/bw_matchbox/assets/templates/match.html
+++ b/bw_matchbox/assets/templates/match.html
@@ -1,59 +1,76 @@
 {% include 'header.html' %}
-<div class="container">
+
+{# Module-specific dependencies... #}
+
+<link rel="stylesheet" href="{{ url_for('static', filename='css/match.css') }}">
+
+{# Core js module #}
+<script src="{{ url_for('static', filename='js/Match/Match.js') }}"></script>
+
+<div id="match-root" class="container match-root">
   {% include 'navigation.html' %}
   <div class="row">
     <div class="column">
       <h2>{{ ds.name }}</h2>
-      <ul>
-        <li>Location: {{ds.location}}</li>
-        <li>Unit: {{ds.unit}}</li>
-        <li>Comment: {{ds.comment}}</li>
+      <ul class="details-list">
+        <li><label>Location:</label> {{ds.location}}</li>
+        <li><label>Unit:</label> {{ds.unit}}</li>
+        <li><label>Comment:</label> {{ds.comment}}</li>
       </ul>
-      <p><input type="text" class="u-full-width" placeholder="Enter value to search" value="{{ query_string }}" id="query_string" /></p>
-      <table id="result-table">
-        <tr>
-          <th>Activity</th>
-          <th>Product</th>
-          <th>Location</th>
-          <th>Unit</th>
-        </tr>
-        {% for obj in matches %}
-        <tr>
-          <td><a href="{{ url_for('compare', source=ds.id, target=obj.id) }}">{{obj.name}}</a></td>
-          <td>{{ obj["reference product"]}}</td>
-          <td>{{ obj.location }}</td>
-          <td>{{ obj.unit }}</td>
-        </tr>
-        {% endfor %}
+      <div><input type="text" class="u-full-width" placeholder="Enter value to search" value="{{ query_string }}" id="query-string" /></div>
+      <div class="info-tableau">
+        <div class="error" id="error">Sample error text</div>
+        <div id="loader-splash" class="loader-splash bg-white full-cover"><div class="loader-spinner"></div></div>
+      </div>
+      <table id="result-table" class="fixed-table">
+        <thead>
+          <tr>
+            <th class="cell-name"><div>Activity</div></th>
+            <th class="cell-referenceProduct"><div>Product</div></th>
+            <th class="cell-location"><div>Location</div></th>
+            <th class="cell-unit"><div>Unit</div></th>
+          </tr>
+        </thead>
+        <tbody id="result-table-body">
+          <!-- ** Generated content - to remove when tested **
+          {% for obj in matches %}
+          <tr>
+            <td class="cell-name"><a href="{{ url_for('compare', source=ds.id, target=obj.id) }}">{{obj.name}}</a></td>
+            <td class="cell-referenceProduct>{{ obj["reference product"] }}</td>
+            <td class="cell-location">{{ obj.location }}</td>
+            <td class="cell-unit">{{ obj.unit }}</td>
+          </tr>
+          {% endfor %}
+          -->
+        </tbody>
       </table>
     </div>
   </div>
 </div>
 
 <script type="text/javascript">
-var searchBar = document.getElementById('query_string');
-searchBar.focus();
-
-var result_table = document.getElementById('result-table');
-function search_result_updater() {
-  result_table.innerHTML = this.responseText;
-}
-
-var doSearch = function () {
-  var qs = encodeURIComponent(searchBar.value);
-  if (qs) {
-    const req = new XMLHttpRequest();
-    req.addEventListener('load', search_result_updater);
-    req.open('GET', '{{ url_for('search') }}?e=1&source={{ ds.id }}&database={{ target }}&q=' + qs);
-    req.send();
+modules.require('Match', function requireMatch(Match) {
+  // Global variables for compare tables feature (via global variable `sharedData`)...
+  const sharedData = {
+    searchUrlPrefix: '{{ url_for('search') }}',
+    source: '{{ ds.id }}',
+    database: '{{ target }}',
+    initialQueryString: '{{ query_string }}',
+    initialTableRows: {{ matches_json|safe }}, // Initial table rows...
+    originalProcess: {
+      name: '{{ ds.name }}',
+      location: '{{ ds.location }}',
+      unit: '{{ ds.unit }}',
+      comment: '{{ ds.comment }}',
+    },
   };
-};
 
-searchBar.addEventListener('focusout', doSearch);
-searchBar.addEventListener('keypress', function(event) {
-  if (event.key === 'Enter') {
-    doSearch();
-  }
+  // Export to global scope (to access from generated html code handlers).
+  window.Match = Match;
+
+  // Start core module...
+  Match.start(sharedData);
 });
+
 </script>
 {% include 'footer.html' %}

--- a/bw_matchbox/assets/templates/process_detail.html
+++ b/bw_matchbox/assets/templates/process_detail.html
@@ -9,11 +9,8 @@
 
 <link rel="stylesheet" href="{{ url_for('static', filename='css/process-detail.css') }}">
 
+{# Core js module #}
 <script src="{{ url_for('static', filename='js/ProcessDetail/ProcessDetail.js') }}"></script>
-
-{# Core js module:
-  - `ProcessDetail` (from `bw_matchbox/assets/js/ProcessDetail/ProcessDetail.js`)
-#}
 
 <div id="process-detail" class="process-detail container{{ ' waitlist' if ds.get('waitlist') }}">
   {% include 'navigation.html' %}

--- a/bw_matchbox/webapp.py
+++ b/bw_matchbox/webapp.py
@@ -437,14 +437,24 @@ def search():
 
     q = flask.request.args.get("q")
     embed = flask.request.args.get("e")
+    json = flask.request.args.get("json")  # Return the data as json
     search_db = flask.request.args.get("database")
 
-    if embed:
+    table_data = bd.Database(search_db or t).search(q, limit=100),
+
+    if json:
+        data = [
+            # TODO: To fix, issue #56: On the client, we need only this data: id, name, referenceProduct, location, unit.
+            dict(x._data, **{'referenceProduct': x.get("reference product")})
+            for x in table_data[0]
+        ]
+        return flask.jsonify(data)
+    elif embed:
         source = bd.get_activity(id=int(flask.request.args.get("source")))
         return flask.render_template(
             "search-embedded.html",
             source=source,
-            table_data=bd.Database(search_db or t).search(q, limit=100),
+            table_data=table_data,  # bd.Database(search_db or t).search(q, limit=100),
         )
     else:
         return flask.render_template(
@@ -456,7 +466,7 @@ def search():
             proxy=proxy,
             user=auth.current_user(),
             title="bw_matchbox Search Result",
-            table_data=bd.Database(search_db).search(q, limit=100),
+            table_data=table_data,  # =bd.Database(search_db).search(q, limit=100),
             query_string=q,
             database=s,
         )
@@ -583,6 +593,11 @@ def match(source):
     node = bd.get_node(id=source)
 
     matches = bd.Database(t).search(node["name"] + " " + node.get("location", ""))
+    matches_data = [
+        # TODO: To fix, issue #56: On the client, we need only this data: id, name, referenceProduct, location, unit.
+        dict(x._data, **{'referenceProduct': x.get("reference product")})
+        for x in matches
+    ]
 
     return flask.render_template(
         "match.html",
@@ -596,6 +611,7 @@ def match(source):
         user=auth.current_user(),
         query_string=node["name"] + " " + node.get("location", ""),
         matches=matches,
+        matches_json=json.dumps(matches_data),
     )
 
 


### PR DESCRIPTION
Moved css rule for `details-list` into `common.css` to reuse on any pages, added styles and js modules for match page, using dynamic table generation on the match page, some temporarily solutions in `webapp.py` module (to fix).