### PR TITLE
Fixes #79: Button icons in the compare page header.

### DIFF
--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -112,3 +112,83 @@
   opacity: 0.5;
   font-weight: normal;
 }
+
+/* Generic page header */
+.common-page-header {
+  /*
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  */
+  margin: 20px 0;
+}
+.common-page-header .title {
+  /* font-size: 2.5rem; */
+  line-height: 1.1;
+  letter-spacing: 0;
+  font-weight: lighter;
+  flex: 1;
+  /* display: flex; */
+}
+.common-page-header .title a {
+  text-decoration: none;
+  color: var(--layout-theme-primary-color-dark1);
+  transition: all var(--common-animation-time);
+}
+.common-page-header .title a:hover {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  /* text-decoration-style: dashed; */
+  /* color: var(--layout-theme-primary-color-dark2); */
+  color: #333;
+}
+.common-page-header .icons {
+  margin-left: 5px;
+  display: inline-block;
+  vertical-align: middle;
+}
+.common-page-header .icons-wrapper {
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 14px;
+}
+.common-page-header .icons-wrapper > a {
+  background-color: var(--layout-theme-primary-color);
+  color: #fff;
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+  width: 28px;
+  height: 28px;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all var(--common-animation-time);
+}
+.common-page-header .icons-wrapper > a.hidden {
+  display: none;
+}
+.common-page-header .icons-wrapper > a.disabled {
+  cursor: dafault;
+  opacity: 0.3;
+  pointer-events: none;
+}
+.common-page-header .icons-wrapper > a:not(.disabled) {
+  cursor: pointer;
+  opacity: 0.5;
+}
+.common-page-header .icons-wrapper > a:not(.disabled):active,
+.common-page-header .icons-wrapper > a:not(.disabled):hover {
+  text-decoration: none;
+  background-color: var(--layout-theme-primary-color-dark1);
+  box-shadow: 0 0 4px var(--layout-theme-primary-color-dark1);
+  opacity: 1;
+  color: #fff;
+}
+.common-page-header .icons-wrapper > a:not(.disabled):active {
+  background-color: var(--layout-theme-primary-color-dark2);
+  box-shadow: 0 0 8px 2px var(--layout-theme-primary-color-dark1);
+}

--- a/bw_matchbox/assets/css/compare.css
+++ b/bw_matchbox/assets/css/compare.css
@@ -53,13 +53,18 @@
   display: flex;
   gap: 5px;
 }
+.compare-table .cell-name div .name-icon,
+.compare-table .cell-name.matched div a {
+  /* Color from `.exact` class */
+  color: #2d8632;
+}
 .compare-table .cell-name div .name-text {
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .compare-table .cell-name div .name-icon {
-  opacity: 0.5;
+  opacity: 0.75;
 }
 .compare-table .cell-name:not(.matched) div .name-icon {
   display: none;

--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -8,10 +8,11 @@
   margin-bottom: 20px;
 }
 
-/* Header */
-.processes-list .page-header h1 {
-  font-size: 200%;
-}
+/* // UNUSED? [> Header <]
+ * .processes-list .page-header h1 {
+ *   font-size: 200%;
+ * }
+ */
 
 /* Empty state: hode some elements... */
 .processes-list.empty .processes-list-table {

--- a/bw_matchbox/assets/js/Compare/CompareCore.js
+++ b/bw_matchbox/assets/js/Compare/CompareCore.js
@@ -129,7 +129,7 @@ modules.define(
           nameContent = `<i class="name-icon fa-solid fa-check"></i><span class="name-text"><a onClick="CompareCore.disableRowClickHandler(this)" href="${url}" class="exact">${name}</a></span>`;
         } else {
           nameContent = `<a onClick="CompareCore.disableRowClickHandler(this)" href="${url}">${name}</a>`;
-        };
+        }
         const end = `<td class="${nameClassName}"><div>${nameContent}</div></td>
           <td class="cell-location"><div>${location}</div></td>
           <td class="cell-unit"><div>${unit}</div></td>
@@ -223,7 +223,7 @@ modules.define(
       },
 
       replaceWithTargetHandler(elem) {
-        CompareRowClick.disableRowClickHandler();
+        // CompareRowClick.disableRowClickHandler(); // NOTE: It's not inside the row
         const { target_node, target_data } = this.sharedData;
         // Trying to make unique row_id...
         const uniqueCounter = ++this.targetNodesCounter;
@@ -234,7 +234,8 @@ modules.define(
         this.sharedData.comment += `* Collapsed input exchanges to target node\n`;
         // TODO: Is sorting required here?
         this.buildTable('target-table', target_data, true);
-        elem.innerHTML = '';
+        // Hide icon...
+        elem.classList.toggle('hidden', true); // Old code: `innerHTML = ''`
       },
 
       removeRowHandler(element) {
@@ -450,7 +451,36 @@ modules.define(
 
       // Copy to clipboard
 
-
+      copyToClipboardHandler(node) {
+        const { sharedData } = this;
+        const nodeType = node.getAttribute('data-node-type');
+        const nameId = nodeType + '_node_name'; // 'source_node_name' | 'target_node_name'
+        const urlId = nodeType + '_node_url'; // 'source_node_url' | 'target_node_url'
+        const name = sharedData[nameId];
+        const url = sharedData[urlId];
+        const text = '[' + name + '](' + url + ')';
+        /* console.log('[CompareCore:copyToClipboardHandler]', {
+         *   urlId,
+         *   nameId,
+         *   url,
+         *   name,
+         *   text,
+         *   nodeType,
+         *   node,
+         * });
+         */
+        // NOTE: Docment should be focused...
+        navigator.clipboard.writeText(text).catch((error) => {
+          // eslint-disable-next-line no-console
+          console.error('[CompareCore:copyToClipboardHandler] Catched error', error);
+          // eslint-disable-next-line no-debugger
+          debugger;
+          // Show errors on the page...
+          // this.setError(error);
+        });
+        // TODO: To catch promise resolve or catch?
+        return false;
+      },
 
       // Start...
 

--- a/bw_matchbox/assets/js/Compare/CompareCore.js
+++ b/bw_matchbox/assets/js/Compare/CompareCore.js
@@ -448,6 +448,10 @@ modules.define(
         event.preventDefault();
       },
 
+      // Copy to clipboard
+
+
+
       // Start...
 
       /** start -- Initialize compare feature (entry point)

--- a/bw_matchbox/assets/js/Compare/CompareCore.js
+++ b/bw_matchbox/assets/js/Compare/CompareCore.js
@@ -124,11 +124,9 @@ modules.define(
         >`;
         // Issue #59: Name cell with check icon for 'matched' rows...
         const nameClassName = `cell-name${matched && ' matched'}`;
-        let nameContent = '';
+        let nameContent = `<a onClick="CompareCore.disableRowClickHandler(this)" href="${url}">${name}</a>`;
         if (!is_target && matched) {
-          nameContent = `<i class="name-icon fa-solid fa-check"></i><span class="name-text"><a onClick="CompareCore.disableRowClickHandler(this)" href="${url}" class="exact">${name}</a></span>`;
-        } else {
-          nameContent = `<a onClick="CompareCore.disableRowClickHandler(this)" href="${url}">${name}</a>`;
+          nameContent = `<i class="name-icon fa-solid fa-check"></i><span class="name-text">${nameContent}</span>`;
         }
         const end = `<td class="${nameClassName}"><div>${nameContent}</div></td>
           <td class="cell-location"><div>${location}</div></td>

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -39,15 +39,36 @@
   </div>
   <div class="row compare-tables">
     <div class="column one-half">
-      <h3><a href="{{ url_for('process_detail', id=source_node.id) }}">{{ source_node.name }}</a> <i onclick="copySourceMarkdown()" class="fa-solid fa-copy"></i></h3>
+      <div class="common-page-header">
+        <h3 class="title">
+          <a href="{{ url_for('process_detail', id=source_node.id) }}" title="Go to process #{{ source_node.id }} page">
+            {{ source_node.name }}
+          </a>
+          <div class="icons">
+            <div class="icons-wrapper">
+              <a onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="source" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
+            </div>
+          </div>
+        </h3>
+      </div>
       <table class="fixed-table fixed-table-active compare-table" id="source-table" width="100%">
       </table>
       <p>{{ source_biosphere_number }} biosphere exchanges</p>
     </div>
     <div class="column one-half">
-      <h3><a href="{{ url_for('process_detail', id=target_node.id) }}">{{ target_node.name }}</a>
-      <i onclick="copyTargetMarkdown()" class="fa-solid fa-copy"></i>
-      <span onclick="CompareCore.replaceWithTargetHandler(this)" id="replace-with-target-arrow"><a><i class="fa-solid fa-arrow-up"></i></a></span></h3>
+      <div class="common-page-header">
+        <h3 class="title">
+          <a href="{{ url_for('process_detail', id=target_node.id) }}" title="Go to process #{{ target_node.id }} page">
+            {{ target_node.name }}
+          </a>
+          <div class="icons">
+            <div class="icons-wrapper">
+              <a onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="target" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
+              <a onClick="CompareCore.replaceWithTargetHandler(this)" id="replace-with-target-arrow" title="Replace with target"><i class="fa-solid fa-arrow-up"></i></a>
+            </div>
+          </div>
+        </h3>
+      </div>
       <table class="fixed-table fixed-table-active compare-table" id="target-table" width="100%">
       </table>
       <p>{{ target_biosphere_number }} biosphere exchanges</p>
@@ -56,6 +77,7 @@
 </div>
 
 <script>
+  /* // ORIGINAL CODE: Clipboard copy
   const sourceText = "[{{ source_node.name }}]({{ base_url}}{{ url_for('process_detail', id=source_node.id) }})";
   const targetText = "[{{ target_node.name }}]({{ base_url}}{{ url_for('process_detail', id=target_node.id) }})";
   const copySourceMarkdown = async () => {
@@ -72,10 +94,16 @@
       console.error('Failed to copy: ', err);
     }
   }
-
+  */
   modules.require('CompareCore', (CompareCore) => {
     // Global variables for compare tables feature (via global variable `sharedData`)...
     const sharedData = {
+      // Data for clipboard copy feature...
+      source_node_name: '{{ source_node.name }}',
+      source_node_url: '{{ base_url}}{{ url_for('process_detail', id=source_node.id) }}',
+      target_node_name: '{{ target_node.name }}',
+      target_node_url: '{{ base_url}}{{ url_for('process_detail', id=target_node.id) }}',
+      // Generic data...
       source_data: {{ source_data_json|safe }}, // TDataRecord[]
       target_data: {{ target_data_json|safe }}, // TDataRecord[]
       target_node: {{ target_json|safe}},


### PR DESCRIPTION
Added `copyToClipboardHandler` method to copy markdown link to clipboard. Created page header layout, icons section, icons css-styles-based behavior.

Fix for issue #59: Fixed styles and layout for 'matched' rows: using `extact' green color for icon, match it by contaning cell `matched` class (don't use extra class for inner elements).

