### PR TITLE
Fixes #34: Disable `replaceWithTargetHandler` action if rows changed.

### DIFF
--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -176,7 +176,8 @@
   display: none;
 }
 .common-page-header .icons-wrapper > a.disabled {
-  cursor: dafault;
+  background-color: #ccc;
+  cursor: default;
   opacity: 0.3;
   pointer-events: none;
 }

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -38,7 +38,7 @@
     </div>
   </div>
   <div class="row collapsed-tools">
-    <button class="button-primary" id="expand-all-collapsed" onClick="">Expand all collapsed rows</button>
+    <button class="button-primary" id="expand-all-collapsed">Expand all collapsed rows</button>
   </div>
   <div class="row compare-tables">
     <div class="column one-half">
@@ -67,7 +67,7 @@
           <div class="icons">
             <div class="icons-wrapper">
               <a onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="target" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
-              <a onClick="CompareCore.replaceWithTargetHandler(this)" id="replace-with-target-arrow" title="Replace with target"><i class="fa-solid fa-arrow-up"></i></a>
+              <a onClick="CompareCore.replaceWithTargetHandler(this)" id="replace-with-target-arrow" title="Collapse process inputs"><i class="fa-solid fa-arrow-up"></i></a>
             </div>
           </div>
         </h3>


### PR DESCRIPTION
Issue #34: Disable `replaceWithTargetHandler` action ('arrow up' button) of any of the row modifications has applied (shiftRowHandler, expandRowHandler, removeRowHandler, editNumberHandler -- actual final handler: setNumberAndCloseModalHandler), other minor fixes.