### PR TITLE
Fixes #82: Fix design for buttons which do bad things

### DIFF
--- a/bw_matchbox/assets/css/common-page-header.css
+++ b/bw_matchbox/assets/css/common-page-header.css
@@ -1,0 +1,115 @@
+/* Generic page header */
+.common-page-header {
+  margin: 20px 0;
+}
+.common-page-header .title {
+  line-height: 1.1;
+  letter-spacing: 0;
+  font-weight: lighter;
+  flex: 1;
+}
+.common-page-header .title a {
+  text-decoration: none;
+  color: var(--layout-theme-primary-color-dark1);
+  transition: all var(--common-animation-time);
+}
+.common-page-header .title a:hover {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  color: #333;
+}
+.common-page-header .tools {
+  margin-left: 5px;
+  display: inline-block;
+  vertical-align: middle;
+}
+.common-page-header .tools-wrapper {
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 14px;
+}
+/* Common tools' items styles */
+.common-page-header .tools-wrapper > a {
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+  height: var(--common-tools-icon-size);
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all var(--common-animation-time);
+  box-sizing: border-box;
+  border: 1px solid var(--layout-theme-primary-color-dark1);
+  user-select: none;
+}
+.common-page-header .tools-wrapper > a.disabled {
+  background-color: transparent;
+  border: 1px solid #ccc;
+  color: #ccc;
+  cursor: default;
+  opacity: 0.5;
+  pointer-events: none;
+}
+.common-page-header .tools-wrapper > a.hidden {
+  display: none;
+}
+/* Tools' icons adjustments... */
+.common-page-header .tools-wrapper > a.tools-icon {
+  width: var(--common-tools-icon-size);
+}
+/* Tools' buttons adjustments... */
+.common-page-header .tools-wrapper > .tools-button {
+  font-weight: bold;
+  font-size: 1em; /* Remove button styles */
+  text-transform: none; /* Remove button styles */
+  margin: 0; /* Remove button margins */
+  line-height: var(--common-tools-icon-size);
+  padding: 0 10px;
+  color: var(--layout-theme-primary-color-dark1);
+}
+/* Active */
+.common-page-header .tools-wrapper > a:not(.disabled) {
+  cursor: pointer;
+  opacity: 0.5;
+}
+.common-page-header .tools-wrapper > a:not(.disabled):active,
+.common-page-header .tools-wrapper > a:not(.disabled):hover {
+  text-decoration: none;
+  box-shadow: 0 0 4px var(--layout-theme-primary-color-dark1);
+  color: var(--layout-theme-primary-color-dark1);
+  opacity: 1;
+}
+.common-page-header .tools-wrapper > a:not(.disabled):active {
+  background-color: var(--layout-theme-primary-color-dark2);
+  color: #fff;
+  box-shadow: 0 0 8px 2px var(--layout-theme-primary-color-dark1);
+}
+/* Theming */
+.common-page-header .tools-wrapper > a:not(.disabled).theme-primary {
+  background-color: var(--layout-theme-primary-color-dark1);
+  border-color: var(--layout-theme-primary-color-dark1);
+}
+.common-page-header .tools-wrapper > a:not(.disabled).theme-success {
+  background-color: var(--common-success-color);
+  border-color: var(--common-success-color);
+}
+.common-page-header .tools-wrapper > a:not(.disabled).theme-warn {
+  background-color: var(--common-warn-color);
+  border-color: var(--common-warn-color);
+}
+.common-page-header .tools-wrapper > a:not(.disabled).theme-error,
+.common-page-header .tools-wrapper > a:not(.disabled).theme-danger {
+  background-color: var(--common-error-color);
+  border-color: var(--common-error-color);
+}
+.common-page-header .tools-wrapper > a:not(.disabled)[class*='theme'],
+.common-page-header .tools-wrapper > a:not(.disabled)[class*='theme']:active,
+.common-page-header .tools-wrapper > a:not(.disabled)[class*='theme']:hover {
+  color: #fff;
+}
+.common-page-header .tools-wrapper > a.theme-danger:not(.disabled) {
+  background-color: var(--common-error-color);
+}

--- a/bw_matchbox/assets/css/common-page-header.md
+++ b/bw_matchbox/assets/css/common-page-header.md
@@ -1,0 +1,25 @@
+# common-page-header
+
+Supports few items' themes:
+
+- theme-primary
+- theme-success
+- theme-warn
+- theme-error
+- theme-danger
+
+Example of different icons & buttons:
+
+```html
+<a class="tools-icon"><i class="fa-solid fa-copy"></i></a>
+<a class="tools-icon theme-primary"><i class="fa-solid fa-copy"></i></a>
+<a class="tools-icon theme-warn"><i class="fa-solid fa-copy"></i></a>
+<a class="tools-icon theme-success"><i class="fa-solid fa-copy"></i></a>
+<a class="tools-icon disabled"><i class="fa-solid fa-copy"></i></a>
+<a id="mark-waitlist" class="tools-button theme-primary">Waitlisted</a>
+<a id="manual-match" class="tools-button theme-primary">No match needed</a>
+<a id="manual-multi-match" class="tools-button theme-primary">Mark all matched</a>
+<a id="match-button" class="tools-button theme-primary">Match</a>
+<a id="match-button" class="tools-button disabled">No match needed</a>
+<a class="tools-button theme-danger">Delete proxy</a>
+```

--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -100,10 +100,10 @@
   column-rule: 1px solid #eee;
   column-width: 300px;
   list-style-type: none;
-  line-height: 1.25;
+  line-height: 1.3;
 }
 .details-list li {
-  margin: 5px 0;
+  margin: 10px 0;
 }
 /* // UNUSED? Using the same width on the all scren widths?
  * @media (width >= 1300px) {
@@ -116,85 +116,4 @@
   display: inline;
   opacity: 0.5;
   font-weight: normal;
-}
-
-/* Generic page header */
-.common-page-header {
-  /*
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  */
-  margin: 20px 0;
-}
-.common-page-header .title {
-  /* font-size: 2.5rem; */
-  line-height: 1.1;
-  letter-spacing: 0;
-  font-weight: lighter;
-  flex: 1;
-  /* display: flex; */
-}
-.common-page-header .title a {
-  text-decoration: none;
-  color: var(--layout-theme-primary-color-dark1);
-  transition: all var(--common-animation-time);
-}
-.common-page-header .title a:hover {
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  /* text-decoration-style: dashed; */
-  /* color: var(--layout-theme-primary-color-dark2); */
-  color: #333;
-}
-.common-page-header .tools {
-  margin-left: 5px;
-  display: inline-block;
-  vertical-align: middle;
-}
-.common-page-header .tools-wrapper {
-  white-space: nowrap;
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 14px;
-}
-.common-page-header .tools-wrapper > a.tools-icon {
-  background-color: var(--layout-theme-primary-color);
-  color: #fff;
-  border-radius: 4px;
-  position: relative;
-  overflow: hidden;
-  width: var(--common-tools-icon-size);
-  height: var(--common-tools-icon-size);
-  text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  transition: all var(--common-animation-time);
-}
-.common-page-header .tools-wrapper > a.tools-icon.hidden {
-  display: none;
-}
-.common-page-header .tools-wrapper > a.tools-icon.disabled {
-  background-color: #ccc;
-  cursor: default;
-  opacity: 0.3;
-  pointer-events: none;
-}
-.common-page-header .tools-wrapper > a.tools-icon:not(.disabled) {
-  cursor: pointer;
-  opacity: 0.5;
-}
-.common-page-header .tools-wrapper > a.tools-icon:not(.disabled):active,
-.common-page-header .tools-wrapper > a.tools-icon:not(.disabled):hover {
-  text-decoration: none;
-  background-color: var(--layout-theme-primary-color-dark1);
-  box-shadow: 0 0 4px var(--layout-theme-primary-color-dark1);
-  opacity: 1;
-  color: #fff;
-}
-.common-page-header .tools-wrapper > a.tools-icon:not(.disabled):active {
-  background-color: var(--layout-theme-primary-color-dark2);
-  box-shadow: 0 0 8px 2px var(--layout-theme-primary-color-dark1);
 }

--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -13,6 +13,7 @@
   --common-error-color: #b00;
   --common-warn-color: #960;
   --common-success-color: #181;
+  --common-tools-icon-size: 28px;
 }
 
 /* Basic layout */
@@ -146,54 +147,54 @@
   /* color: var(--layout-theme-primary-color-dark2); */
   color: #333;
 }
-.common-page-header .icons {
+.common-page-header .tools {
   margin-left: 5px;
   display: inline-block;
   vertical-align: middle;
 }
-.common-page-header .icons-wrapper {
+.common-page-header .tools-wrapper {
   white-space: nowrap;
   display: flex;
   align-items: center;
   gap: 5px;
   font-size: 14px;
 }
-.common-page-header .icons-wrapper > a {
+.common-page-header .tools-wrapper > a.tools-icon {
   background-color: var(--layout-theme-primary-color);
   color: #fff;
   border-radius: 4px;
   position: relative;
   overflow: hidden;
-  width: 28px;
-  height: 28px;
+  width: var(--common-tools-icon-size);
+  height: var(--common-tools-icon-size);
   text-align: center;
   display: flex;
   justify-content: center;
   align-items: center;
   transition: all var(--common-animation-time);
 }
-.common-page-header .icons-wrapper > a.hidden {
+.common-page-header .tools-wrapper > a.tools-icon.hidden {
   display: none;
 }
-.common-page-header .icons-wrapper > a.disabled {
+.common-page-header .tools-wrapper > a.tools-icon.disabled {
   background-color: #ccc;
   cursor: default;
   opacity: 0.3;
   pointer-events: none;
 }
-.common-page-header .icons-wrapper > a:not(.disabled) {
+.common-page-header .tools-wrapper > a.tools-icon:not(.disabled) {
   cursor: pointer;
   opacity: 0.5;
 }
-.common-page-header .icons-wrapper > a:not(.disabled):active,
-.common-page-header .icons-wrapper > a:not(.disabled):hover {
+.common-page-header .tools-wrapper > a.tools-icon:not(.disabled):active,
+.common-page-header .tools-wrapper > a.tools-icon:not(.disabled):hover {
   text-decoration: none;
   background-color: var(--layout-theme-primary-color-dark1);
   box-shadow: 0 0 4px var(--layout-theme-primary-color-dark1);
   opacity: 1;
   color: #fff;
 }
-.common-page-header .icons-wrapper > a:not(.disabled):active {
+.common-page-header .tools-wrapper > a.tools-icon:not(.disabled):active {
   background-color: var(--layout-theme-primary-color-dark2);
   box-shadow: 0 0 8px 2px var(--layout-theme-primary-color-dark1);
 }

--- a/bw_matchbox/assets/css/customizations.css
+++ b/bw_matchbox/assets/css/customizations.css
@@ -33,18 +33,22 @@
 }
 
 .narrower {
+  /* TODO: To use common color? */
   color: #592a71;
 }
 
 .broader {
+  /* TODO: To use common color `--common-error-color: #b00` */
   color: #aa3c39;
 }
 
 .exact {
+  /* TODO: To use common color `--common-success-color: #181` */
   color: #2d8632;
 }
 
 .approximate {
+  /* TODO: To use common color `--common-warn-color: #960` */
   color: #a8aa39;
 }
 
@@ -55,6 +59,8 @@
 .button.button-danger,
 button.button-danger {
   color: #fff;
-  background-color: #592a71;
-  border-color: #592a71;
+  /* background-color: #592a71; */
+  /* border-color: #592a71; */
+  background-color: var(--common-error-color);
+  border-color: var(--common-error-color);
 }

--- a/bw_matchbox/assets/css/process-detail.css
+++ b/bw_matchbox/assets/css/process-detail.css
@@ -46,3 +46,20 @@
   cursor: default;
   user-select: none;
 }
+
+/* Table */
+.process-detail .fixed-table .cell-amount {
+  width: 14em;
+}
+.process-detail .fixed-table .cell-name {
+  width: auto;
+}
+.process-detail .fixed-table .cell-location {
+  width: 12em;
+}
+.process-detail .fixed-table .cell-unit {
+  width: 5em;
+}
+.process-detail .fixed-table .cell-matched {
+  width: 8em;
+}

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -47,9 +47,9 @@
           <a href="{{ url_for('process_detail', id=source_node.id) }}" title="Go to process #{{ source_node.id }} page">
             {{ source_node.name }}
           </a>
-          <div class="icons">
-            <div class="icons-wrapper">
-              <a onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="source" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
+          <div class="tools">
+            <div class="tools-wrapper">
+              <a class="tools-icon" onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="source" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
             </div>
           </div>
         </h3>
@@ -64,10 +64,10 @@
           <a href="{{ url_for('process_detail', id=target_node.id) }}" title="Go to process #{{ target_node.id }} page">
             {{ target_node.name }}
           </a>
-          <div class="icons">
-            <div class="icons-wrapper">
-              <a onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="target" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
-              <a onClick="CompareCore.replaceWithTargetHandler(this)" id="replace-with-target-arrow" title="Collapse process inputs"><i class="fa-solid fa-arrow-up"></i></a>
+          <div class="tools">
+            <div class="tools-wrapper">
+              <a class="tools-icon" onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="target" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
+              <a class="tools-icon" onClick="CompareCore.replaceWithTargetHandler(this)" id="replace-with-target-arrow" title="Collapse process inputs"><i class="fa-solid fa-arrow-up"></i></a>
             </div>
           </div>
         </h3>

--- a/bw_matchbox/assets/templates/compare.html
+++ b/bw_matchbox/assets/templates/compare.html
@@ -49,7 +49,7 @@
           </a>
           <div class="tools">
             <div class="tools-wrapper">
-              <a class="tools-icon" onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="source" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
+              <a class="tools-icon theme-primary" onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="source" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
             </div>
           </div>
         </h3>
@@ -66,8 +66,8 @@
           </a>
           <div class="tools">
             <div class="tools-wrapper">
-              <a class="tools-icon" onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="target" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
-              <a class="tools-icon" onClick="CompareCore.replaceWithTargetHandler(this)" id="replace-with-target-arrow" title="Collapse process inputs"><i class="fa-solid fa-arrow-up"></i></a>
+              <a class="tools-icon theme-primary" onClick="CompareCore.copyToClipboardHandler(this)" data-node-type="target" title="Copy markdown link to clipboard"><i class="fa-solid fa-copy"></i></a>
+              <a class="tools-icon theme-primary" onClick="CompareCore.replaceWithTargetHandler(this)" id="replace-with-target-arrow" title="Collapse process inputs"><i class="fa-solid fa-arrow-up"></i></a>
             </div>
           </div>
         </h3>

--- a/bw_matchbox/assets/templates/header.html
+++ b/bw_matchbox/assets/templates/header.html
@@ -26,9 +26,10 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/normalize.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/tooltip.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/skeleton.css') }}">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/customizations.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/customizations.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/fixed-table.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/common-page-header.css') }}">
 
   <!-- Scripts
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->

--- a/bw_matchbox/assets/templates/process_detail.html
+++ b/bw_matchbox/assets/templates/process_detail.html
@@ -21,24 +21,21 @@
           {{ ds.name }}
           <div class="tools">
             <div class="tools-wrapper">
-              <a class="tools-icon DEBUG" title="DEBUG"><i class="fa-solid fa-copy"></i></a>
               {% if ds.database == source and config.role == 'editors'  %}
-                <button id="mark-waitlist" class="tools-button button{{ ' button-primary' if not ds.get('waitlist') }}" onClick="ProcessDetail.markWaitlist(this)">{{ 'Waitlisted' if ds.waitlist else 'Waitlist' }}</button>
+                <a id="mark-waitlist" class="tools-button {{ ' theme-primary' if not ds.get('waitlist') }}" onClick="ProcessDetail.markWaitlist(this)">{{ 'Waitlisted' if ds.waitlist else 'Waitlist' }}</a>
                 {% if not ds.matched %}
-                  <button id="manual-match" class="tools-button button button-primary" onClick="ProcessDetail.markMatched(this)">No match needed</button>
+                  <a id="manual-match" class="tools-button theme-primary" onClick="ProcessDetail.markMatched(this)">No match needed</a>
                   {% if same_name_count %}
-                    <button id="manual-multi-match" class="tools-button button button-primary" onClick="ProcessDetail.markAllMatched(this)">Mark all matched</button>
+                    <a id="manual-multi-match" class="tools-button theme-primary" onClick="ProcessDetail.markAllMatched(this)">Mark all matched</a>
                   {% endif %}
-                  <a id="match-button" class="tools-button button button-primary" href="{{ url_for('match', source=ds.id)}}">Match</a>
+                  <a id="match-button" class="tools-button theme-primary" href="{{ url_for('match', source=ds.id)}}">Match</a>
                 {% else %}
-                  <button id="match-button" class="tools-button button disabled">{% if ds.match_type == "1" %}No match needed{% else %}Matched{% endif %}</button>
+                  <a id="match-button" class="tools-button disabled">{% if ds.match_type == "1" %}No match needed{% else %}Matched{% endif %}</a>
                 {% endif %}
               {% endif %}
-              {# // DEBUG: Condition has temporarily disabled for debug! Don't forget to re-enable when done.
               {% if is_proxy and config.role == 'editors' %}
+                <a class="tools-button theme-danger" href="{{ url_for('delete_proxy', id=ds.id)}}">Delete proxy</a>
               {% endif %}
-              #}
-              <a class="button button-danger" href="{{ url_for('delete_proxy', id=ds.id)}}">Delete proxy</a>
             </div>
           </div>
         </h3>
@@ -69,22 +66,22 @@
         <div class="error" id="error">Sample error text</div>
         <div id="loader-splash" class="loader-splash bg-white full-cover"><div class="loader-spinner"></div></div>
       </div>
-      <h2>Technosphere Inputs</h2>
-      <table width="100%">
+      <h3>Technosphere Inputs</h3>
+      <table class="fixed-table" width="100%">
         <tr>
-          <th>Amount</th>
-          <th>Name</th>
-          <th>Location</th>
-          <th>Unit</th>
-          <th>Matched</th>
+          <th class="cell-amount"><div>Amount</div></th>
+          <th class="cell-name"><div>Name</div></th>
+          <th class="cell-location"><div>Location</div></th>
+          <th class="cell-unit"><div>Unit</div></th>
+          <th class="cell-matched"><div>Matched</div></th>
         </tr>
         {% for row in technosphere %}
         <tr>
-          <td>{{row.amount}}</td>
-          <td><a href="{{ url_for('process_detail', id=row.input.id) }}">{{row.input.name}}</a></td>
-          <td>{{row.input.location}}</td>
-          <td>{{row.input.unit}}</td>
-          <td>{% if row.input.matched %}<i class="fa-solid fa-check"></i>{% else %}<i class="fa-solid fa-circle-xmark"></i>{% endif %}</td>
+          <td><div>{{row.amount}}</div></td>
+          <td><div><a href="{{ url_for('process_detail', id=row.input.id) }}">{{row.input.name}}</a></div></td>
+          <td><div>{{row.input.location}}</div></td>
+          <td><div>{{row.input.unit}}</div></td>
+          <td><div>{% if row.input.matched %}<i class="fa-solid fa-check"></i>{% else %}<i class="fa-solid fa-circle-xmark"></i>{% endif %}</div></td>
         </tr>
         {% endfor %}
       </table>
@@ -92,19 +89,19 @@
       {% if biosphere|length > 50 or not biosphere|length %}
       <p>{{ biosphere|length }} biosphere exchanges</p>
       {% else %}
-      <table width="100%">
+      <table class="fixed-table" width="100%">
         <tr>
-          <th>Amount</th>
-          <th>Name</th>
-          <th>Categories</th>
-          <th>Unit</th>
+          <th class="cell-amount"><div>Amount</div></th>
+          <th class="cell-name"><div>Name</div></th>
+          <th class="cell-categories"><div>Categories</div></th>
+          <th class="cell-unit"><div>Unit</div></th>
         </tr>
         {% for exc in biosphere %}
           <tr>
-            <td>{{ exc.amount }}</td>
-            <td>{{ exc.input.name }}</td>
-            <td>{{ exc.input.categories|join("|") }}</td>
-            <td>{{ exc.input.unit }}</td>
+            <td><div>{{ exc.amount }}</div></td>
+            <td><div>{{ exc.input.name }}</div></td>
+            <td><div>{{ exc.input.categories|join("|") }}</div></td>
+            <td><div>{{ exc.input.unit }}</div></td>
           </tr>
         {% endfor %}
       {% endif %}
@@ -116,19 +113,19 @@
       <p>Showing 50 of {{ total_consumers }}</p>
       {% endif %}
       {% if total_consumers %}
-      <table width="100%">
+      <table class="fixed-table" width="100%">
         <tr>
-          <th>Amount</th>
-          <th>Name</th>
-          <th>Location</th>
-          <th>Unit</th>
+          <th class="cell-amount"><div>Amount</div></th>
+          <th class="cell-name"><div>Name</div></th>
+          <th class="cell-location"><div>Location</div></th>
+          <th class="cell-unit"><div>Unit</div></th>
         </tr>
         {% for exc in consumers %}
           <tr>
-            <td>{{ exc.amount }}</td>
-            <td><a href="{{ url_for('process_detail', id=exc.output.id) }}">{{ exc.output.name }}</a></td>
-            <td>{{ exc.output.location }}</td>
-            <td>{{ exc.output.unit }}</td>
+            <td><div>{{ exc.amount }}</div></td>
+            <td><div><a href="{{ url_for('process_detail', id=exc.output.id) }}">{{ exc.output.name }}</a></div></td>
+            <td><div>{{ exc.output.location }}</div></td>
+            <td><div>{{ exc.output.unit }}</div></td>
           </tr>
         {% endfor %}
       {% endif %}

--- a/bw_matchbox/assets/templates/process_detail.html
+++ b/bw_matchbox/assets/templates/process_detail.html
@@ -16,16 +16,33 @@
   {% include 'navigation.html' %}
   <div class="row">
     <div class="column">
-      <h1>{{ ds.name }}
-        {% if ds.database == source and config.role == 'editors'  %}
-          <button onClick="ProcessDetail.markWaitlist(this)" style="vertical-align: middle" class="{{ 'button-primary' if not ds.get('waitlist') }}" id="mark-waitlist">{{ 'Waitlisted' if ds.waitlist else 'Waitlist' }}</button>
-          {% if not ds.matched %}<button onClick="ProcessDetail.markMatched(this)" style="vertical-align: middle" class="button-primary" id="manual-match">No match needed</button>
-          {% if same_name_count %}<button onClick="ProcessDetail.markAllMatched(this)" style="vertical-align: middle" class="button-primary" id="manual-multi-match">Mark all matched</button>{% endif %}
-          <a style="vertical-align: middle" id="match-button" class="button button-primary" href="{{ url_for('match', source=ds.id)}}">Match</a>{% elif ds.match_type == "1" %}<button id="match-button" style="vertical-align: middle" class="disabled">No match needed</button>{% else %}<button id="match-button" style="vertical-align: middle">Matched</button>{% endif %}
-        {% endif %}{% if is_proxy and config.role == 'editors' %}
-        <a href="{{ url_for('delete_proxy', id=ds.id)}}" class="button button-danger">Delete proxy</a>
-        {% endif %}
-      </h1>
+      <div class="common-page-header">
+        <h3 class="title">
+          {{ ds.name }}
+          <div class="tools">
+            <div class="tools-wrapper">
+              <a class="tools-icon DEBUG" title="DEBUG"><i class="fa-solid fa-copy"></i></a>
+              {% if ds.database == source and config.role == 'editors'  %}
+                <button id="mark-waitlist" class="tools-button button{{ ' button-primary' if not ds.get('waitlist') }}" onClick="ProcessDetail.markWaitlist(this)">{{ 'Waitlisted' if ds.waitlist else 'Waitlist' }}</button>
+                {% if not ds.matched %}
+                  <button id="manual-match" class="tools-button button button-primary" onClick="ProcessDetail.markMatched(this)">No match needed</button>
+                  {% if same_name_count %}
+                    <button id="manual-multi-match" class="tools-button button button-primary" onClick="ProcessDetail.markAllMatched(this)">Mark all matched</button>
+                  {% endif %}
+                  <a id="match-button" class="tools-button button button-primary" href="{{ url_for('match', source=ds.id)}}">Match</a>
+                {% else %}
+                  <button id="match-button" class="tools-button button disabled">{% if ds.match_type == "1" %}No match needed{% else %}Matched{% endif %}</button>
+                {% endif %}
+              {% endif %}
+              {# // DEBUG: Condition has temporarily disabled for debug! Don't forget to re-enable when done.
+              {% if is_proxy and config.role == 'editors' %}
+              {% endif %}
+              #}
+              <a class="button button-danger" href="{{ url_for('delete_proxy', id=ds.id)}}">Delete proxy</a>
+            </div>
+          </div>
+        </h3>
+      </div>
       <ul class="details-list">
           <li><label>Database:</label> {{ ds.database }}</li>
           <li><label>Location:</label> {{ ds.location }}</li>


### PR DESCRIPTION
Issue #82: Refactored styles for `common-page-header` sections, in particular, styles for tools sections. Now it possible to mix there icons and buttons and to use different themings for them: theme-primary, theme-success, theme-warn, theme-error, theme-danger (see examples in `common-page-header.md`). Other minor changes (fixed-table tables on process-detail page), updated tools icons on the compare page (solid blue icons should be now `theme-primary`).