### PR TITLE
Updates #100: Fixed code for matched column content generation on process list template.

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,5 +1,5 @@
 trailingComma: 'all'
-printWidth: 120
+printWidth: 100
 tabWidth: 2
 semi: true
 singleQuote: true

--- a/bw_matchbox/assets/css/comments-threads-list.css
+++ b/bw_matchbox/assets/css/comments-threads-list.css
@@ -170,7 +170,11 @@
   margin-right: -2px;
 }
 /* Disable some actions */
-.comments-root:not(.role-editors, .role-reviewers) .threads-list .thread .title-actions a#threadAddComment,
+.comments-root:not(.role-editors, .role-reviewers)
+  .threads-list
+  .thread
+  .title-actions
+  a#threadAddComment,
 .comments-root:not(.role-editors) .threads-list .thread .title-actions a#threadResolve {
   display: none;
 }

--- a/bw_matchbox/assets/js/Comments/CommentsDataRender.js
+++ b/bw_matchbox/assets/js/Comments/CommentsDataRender.js
@@ -36,7 +36,9 @@ modules.define(
       getVisibleCommentsForThread(threadId) {
         const { commentsHash, commentsByThreads } = CommentsData;
         const commentsByThreadsIds = commentsByThreads[threadId];
-        const visibleCommentIds = commentsByThreadsIds.filter(CommentsThreadsHelpers.isCommentVisible);
+        const visibleCommentIds = commentsByThreadsIds.filter(
+          CommentsThreadsHelpers.isCommentVisible,
+        );
         const commentsList = visibleCommentIds.map((id) => commentsHash[id]);
         return commentsList;
       },
@@ -358,7 +360,9 @@ modules.define(
       clearAllHiddenThreadsComments() {
         // const rootNode = CommentsNodes.getRootNode();
         const threadsListNode = CommentsNodes.getThreadsListNode();
-        const hiddenCommentNodes = threadsListNode.querySelectorAll('.thread:not(.expanded) .comments.ready');
+        const hiddenCommentNodes = threadsListNode.querySelectorAll(
+          '.thread:not(.expanded) .comments.ready',
+        );
         /* console.log('[CommentsDataRender:clearAllHiddenThreadsComments]', {
          *   threadsListNode,
          *   hiddenCommentNodes,
@@ -429,7 +433,9 @@ modules.define(
         this.clearAllHiddenThreadsComments();
         // Find all expanded threads...
         const threadsListNode = CommentsNodes.getThreadsListNode();
-        const visibleThreadNodes = threadsListNode.querySelectorAll('.thread:not(.hidden).expanded');
+        const visibleThreadNodes = threadsListNode.querySelectorAll(
+          '.thread:not(.hidden).expanded',
+        );
         /* console.log('[CommentsDataRender:rerenderAllVisibleComments]', {
          *   visibleThreadNodes,
          * });

--- a/bw_matchbox/assets/js/Comments/CommentsHandlers.js
+++ b/bw_matchbox/assets/js/Comments/CommentsHandlers.js
@@ -90,7 +90,9 @@ modules.define(
               resolve(userAction);
             }
           });
-          document.getElementById('comment-modal-cancel').addEventListener('click', CommonModal.boundHideModal);
+          document
+            .getElementById('comment-modal-cancel')
+            .addEventListener('click', CommonModal.boundHideModal);
         });
       },
     };
@@ -146,7 +148,8 @@ modules.define(
               if (!ok) {
                 // Something went wrong?
                 const reason =
-                  [statusText, status && 'status: ' + status].filter(Boolean).join(', ') || 'Unknown error';
+                  [statusText, status && 'status: ' + status].filter(Boolean).join(', ') ||
+                  'Unknown error';
                 const error = new Error('Data loading error: ' + reason);
                 // eslint-disable-next-line no-console
                 console.error('[CommentsHandlers:apiHandlers:threadAddCommentRequest]: on then', {
@@ -183,7 +186,8 @@ modules.define(
               CommentsHelpers.sortThreads(threads);
               // Update content...
               const threadTitleTextNode = threadNode.querySelector('.title-text');
-              const threadTitleTextContent = CommentsDataRender.helpers.createThreadTitleTextContent(thread);
+              const threadTitleTextContent =
+                CommentsDataRender.helpers.createThreadTitleTextContent(thread);
               /* console.log('[CommentsHandlers:apiHandlers:threadAddCommentRequest]: done', {
                *   commentId,
                *   comment,
@@ -262,7 +266,9 @@ modules.define(
         const { currentRole } = sharedParams;
         // Check roles...
         if (currentRole !== 'editors') {
-          CommonNotify.showError(`This role (${currentRole}) hasn't allowed to resolve/open the threads`);
+          CommonNotify.showError(
+            `This role (${currentRole}) hasn't allowed to resolve/open the threads`,
+          );
           return;
         }
         const thread = threadsHash[threadId];
@@ -305,7 +311,9 @@ modules.define(
             const { ok, status, statusText } = res;
             if (!ok) {
               // Something went wrong?
-              const reason = [statusText, status && 'status: ' + status].filter(Boolean).join(', ') || 'Unknown error';
+              const reason =
+                [statusText, status && 'status: ' + status].filter(Boolean).join(', ') ||
+                'Unknown error';
               const error = new Error('Data loading error: ' + reason);
               // eslint-disable-next-line no-console
               console.error('[CommentsHandlers:apiHandlers:threadResolve]: error (on then)', {
@@ -332,7 +340,8 @@ modules.define(
             // thread.modified = currDateStr;
             // Update content...
             const threadTitleTextNode = threadNode.querySelector('.title-text');
-            const threadTitleTextContent = CommentsDataRender.helpers.createThreadTitleTextContent(thread);
+            const threadTitleTextContent =
+              CommentsDataRender.helpers.createThreadTitleTextContent(thread);
             /* console.log('[CommentsHandlers:apiHandlers:threadResolve]: done', {
              *   resolved,
              *   thread,
@@ -539,7 +548,9 @@ modules.define(
         const threadNodes = threadsListNode.querySelectorAll('.thread:not(.hidden)');
         const threadNodesList = Array.from(threadNodes);
         const allCount = threadNodesList.length;
-        const expandedThreads = threadNodesList.filter((node) => node.classList.contains('expanded'));
+        const expandedThreads = threadNodesList.filter((node) =>
+          node.classList.contains('expanded'),
+        );
         const expandedCount = expandedThreads.length;
         const isCollapsed = !expandedCount;
         const isExpanded = !isCollapsed && expandedCount === allCount;

--- a/bw_matchbox/assets/js/Comments/CommentsLoader.js
+++ b/bw_matchbox/assets/js/Comments/CommentsLoader.js
@@ -49,7 +49,9 @@ modules.define(
             const { ok, status, statusText } = res;
             if (!ok) {
               // Something went wrong?
-              const reason = [statusText, status && 'status: ' + status].filter(Boolean).join(', ') || 'Unknown error';
+              const reason =
+                [statusText, status && 'status: ' + status].filter(Boolean).join(', ') ||
+                'Unknown error';
               const error = new Error('Data loading error: ' + reason);
               // eslint-disable-next-line no-console
               console.error('[CommentsLoader:loadComments]: error (on then)', {
@@ -68,7 +70,12 @@ modules.define(
             return res.json();
           })
           .then((json) => {
-            const { comments, threads, total_comments: totalComments, total_threads: totalThreads } = json;
+            const {
+              comments,
+              threads,
+              total_comments: totalComments,
+              total_threads: totalThreads,
+            } = json;
             const hasData = Array.isArray(comments) && !!comments.length;
             /* console.log('[CommentsLoader:loadComments]: got comments', {
              *   json,

--- a/bw_matchbox/assets/js/Compare/CompareCore.js
+++ b/bw_matchbox/assets/js/Compare/CompareCore.js
@@ -51,7 +51,18 @@ modules.define(
         // NOTE: Row operations handlers: shiftRowHandler, editNumberHandler, expandRowHandler, removeRowHandler
         // Reg: \<\(shiftRowHandler\|editNumberHandler\|expandRowHandler\|removeRowHandler\>\)
         const { collapsedRows } = CompareRowsHelpers;
-        const { collapsed, row_id: rowId, url, location, unit, amount_display, amount, name, input_id, matched } = data;
+        const {
+          collapsed,
+          row_id: rowId,
+          url,
+          location,
+          unit,
+          amount_display,
+          amount,
+          name,
+          input_id,
+          matched,
+        } = data;
         const rowKind = is_target ? 'target' : 'source';
         const collapsedId = CompareRowsHelpers.getCollapsedId(rowKind, rowId);
         if (collapsed && !collapsedRows[collapsedId] && collapsedRows[collapsedId] !== false) {
@@ -59,7 +70,9 @@ modules.define(
           const otherTableDataKey = otherRowKind + '_data';
           const otherTableData = this.sharedData[otherTableDataKey];
           const collapsedGroupId = data['collapsed-group'];
-          const otherRowData = otherTableData.find((other) => other['collapsed-group'] === collapsedGroupId);
+          const otherRowData = otherTableData.find(
+            (other) => other['collapsed-group'] === collapsedGroupId,
+          );
           if (!otherRowData) {
             throw new Error('Cannot find other collapsed record');
           }
@@ -82,7 +95,8 @@ modules.define(
         }
         // Detect if row is collapsed, then render correspound class (`collapsed`) and append handler node...
         const isCollapsed = !!collapsedRows[collapsedId];
-        const collapsedRowHtml = isCollapsed && CompareRowsHelpers.buildCollapsedHandlerRow(rowKind, rowId, data);
+        const collapsedRowHtml =
+          isCollapsed && CompareRowsHelpers.buildCollapsedHandlerRow(rowKind, rowId, data);
         // Create class name...
         const className = [isCollapsed && 'collapsed'].filter(Boolean).join(' ');
         const trAttrs = [['class', className], isCollapsed && ['collapsed-id', collapsedId]]
@@ -270,7 +284,9 @@ modules.define(
         fetch(url)
           .then((res) => {
             if (!res.ok) {
-              const error = new Error(`Can't load url '${res.url}': ${res.statusText}, ${res.status}`);
+              const error = new Error(
+                `Can't load url '${res.url}': ${res.statusText}, ${res.status}`,
+              );
               throw error;
             }
             return res.json();
@@ -455,12 +471,18 @@ modules.define(
           .showModal();
 
         // Set modal handlers...
-        document.getElementById('rescale-button').addEventListener('click', this.rescaleAmountHandler.bind(this));
-        document.getElementById('new-number-button').addEventListener('click', this.setNewNumberHandler.bind(this));
+        document
+          .getElementById('rescale-button')
+          .addEventListener('click', this.rescaleAmountHandler.bind(this));
+        document
+          .getElementById('new-number-button')
+          .addEventListener('click', this.setNewNumberHandler.bind(this));
         document
           .getElementById('set-and-close-number-editor')
           .addEventListener('click', this.setNumberAndCloseModalHandler.bind(this));
-        document.getElementById('reset-number').addEventListener('click', this.resetNumberHandler.bind(this));
+        document
+          .getElementById('reset-number')
+          .addEventListener('click', this.resetNumberHandler.bind(this));
       },
 
       stop(event) {
@@ -490,7 +512,9 @@ modules.define(
             // eslint-disable-next-line no-debugger
             debugger;
             // Show error in the notification toast...
-            CommonNotify.showError(`Can't copy text to clipboard: ${CommonHelpers.getErrorText(error)}`);
+            CommonNotify.showError(
+              `Can't copy text to clipboard: ${CommonHelpers.getErrorText(error)}`,
+            );
           });
         // TODO: To catch promise resolve or catch?
         return false;
@@ -526,7 +550,11 @@ modules.define(
         // Button handlers...
         document
           .getElementById('save-mapping-button')
-          .addEventListener('click', CompareProxyDialogModal.openProxyDialogModal.bind(CompareProxyDialogModal), false);
+          .addEventListener(
+            'click',
+            CompareProxyDialogModal.openProxyDialogModal.bind(CompareProxyDialogModal),
+            false,
+          );
         document
           .getElementById('one-to-one')
           .addEventListener(
@@ -536,7 +564,10 @@ modules.define(
           );
 
         const expandAll = document.getElementById('expand-all-collapsed');
-        expandAll.addEventListener('click', CompareRowsHelpers.expandAllCollapsedRows.bind(CompareRowsHelpers));
+        expandAll.addEventListener(
+          'click',
+          CompareRowsHelpers.expandAllCollapsedRows.bind(CompareRowsHelpers),
+        );
       },
 
       // Re-exported handlers for access from the html code (only core module is exposed as global)...

--- a/bw_matchbox/assets/js/Compare/CompareProxyDialogModal.js
+++ b/bw_matchbox/assets/js/Compare/CompareProxyDialogModal.js
@@ -68,7 +68,8 @@ modules.define(
        * @return {string}
        */
       renderProxyModalContent() {
-        const { source_node_unit, source_node_location, target_data, match_types, comment } = this.sharedData;
+        const { source_node_unit, source_node_location, target_data, match_types, comment } =
+          this.sharedData;
         const selectedMatchType = this.getSelectedMatchType();
 
         const name = this.getTargetProxyName();

--- a/bw_matchbox/assets/js/Match/Match.js
+++ b/bw_matchbox/assets/js/Match/Match.js
@@ -136,7 +136,9 @@ modules.define(
           .then((res) => {
             // TODO: if (!res.ok) ...
             if (!res.ok) {
-              const error = new Error(`Can't load url '${res.url}': ${res.statusText}, ${res.status}`);
+              const error = new Error(
+                `Can't load url '${res.url}': ${res.statusText}, ${res.status}`,
+              );
               throw error;
             } else {
               // return res.text();

--- a/bw_matchbox/assets/js/ProcessDetail/ProcessDetail.js
+++ b/bw_matchbox/assets/js/ProcessDetail/ProcessDetail.js
@@ -144,9 +144,11 @@ modules.define(
         const makeUrlParams = { addQuestionSymbol: true, useEmptyStrings: true };
         const urls = [
           // Url #1, Eg: ?attr=match_type&value=1
-          urlBase + CommonHelpers.makeQuery({ attr: 'waitlist', value: waitlistValue }, makeUrlParams),
+          urlBase +
+            CommonHelpers.makeQuery({ attr: 'waitlist', value: waitlistValue }, makeUrlParams),
           // Url #2, Eg: ?attr=waitlist_comment&value=<comment text>
-          urlBase + CommonHelpers.makeQuery({ attr: 'waitlist_comment', value: comment }, makeUrlParams),
+          urlBase +
+            CommonHelpers.makeQuery({ attr: 'waitlist_comment', value: comment }, makeUrlParams),
         ].filter(Boolean);
         // Call both requests at once...
         const callbacks = urls.map((url) => () => fetch(url));
@@ -238,7 +240,9 @@ modules.define(
         fetch(url)
           .then((res) => {
             if (!res.ok) {
-              const error = new Error(`Can't load url '${res.url}': ${res.statusText}, ${res.status}`);
+              const error = new Error(
+                `Can't load url '${res.url}': ${res.statusText}, ${res.status}`,
+              );
               // eslint-disable-next-line no-console
               console.error('[ProcessDetail:markAllMatched] Got error', error);
               // eslint-disable-next-line no-debugger

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataLoad.js
@@ -31,9 +31,15 @@ modules.define(
        * @param {boolean} [opts.update] - Update current data chunk.
        */
       loadData(/* opts = {} */) {
-        const { currentPage, orderBy, filterBy, userDb, searchValue, sharedParams, hasSearch } = ProcessesListData;
+        const { currentPage, orderBy, filterBy, userDb, searchValue, sharedParams, hasSearch } =
+          ProcessesListData;
         const { databases } = sharedParams;
-        const { pageSize, processesApiUrl: urlBase, defaultOrderBy, defaultFilterBy } = ProcessesListConstants;
+        const {
+          pageSize,
+          processesApiUrl: urlBase,
+          defaultOrderBy,
+          defaultFilterBy,
+        } = ProcessesListConstants;
         const userDbValue = databases[userDb]; // Could it be empty? Eg, to use: `|| database`
         const offset = currentPage * pageSize; // TODO!
         const params = {
@@ -53,7 +59,9 @@ modules.define(
             const { ok, status, statusText } = res;
             if (!ok) {
               // Something went wrong?
-              const reason = [statusText, status && 'status: ' + status].filter(Boolean).join(', ') || 'Unknown error';
+              const reason =
+                [statusText, status && 'status: ' + status].filter(Boolean).join(', ') ||
+                'Unknown error';
               const error = new Error('Data loading error: ' + reason);
               // eslint-disable-next-line no-console
               console.error('[ProcessesListDataLoad:loadData]: error (on then)', {

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataRender.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataRender.js
@@ -37,45 +37,35 @@ modules.define(
         const {
           id, // 726 (required!)
           match_type, // 'No direct match available'
+          matched, // false
           /* // Other unused process record data...
            * name, // 'Electronic capacitors, resistors, coils, transformers, connectors and other components (except  semiconductors and printed circuit assemblies); at manufacturer'
            * location, // 'United States'
            * unit, // ''
            * details_url, // '/process/726'
            * match_url, // '/match/726'
-           * matched, // false
            */
         } = rowData;
         const hasMatchType = !!match_type;
-        let matchContent;
         if (isEditor) {
           const matchUrl = '/match/' + id;
-          matchContent = `<a href="${matchUrl}">
-            <i class="fa-solid fa-circle-xmark"></i>
-            Add match
-          </a>`;
+          const matchText = matched ? match_type || 'Edit' : 'Add';
+          const matchIcon = matched ? 'fa-check' : 'fa-circle-xmark';
+          const matchClass = !matched && 'button button-primary';
+          // Old, button action involved `matched` parameter
+          return `<a
+            class="${matchClass}"
+            href="${matchUrl}">
+              <i class="fa-solid ${matchIcon}"></i>
+              ${matchText}
+            </a>`;
         } else if (hasProxy) {
-          matchContent = `<a href="/process/${proxy}">Proxy dataset</a>`;
+          return `<a href="/process/${proxy}">Proxy dataset</a>`;
         } else if (hasMatchType) {
-          matchContent = `No match needed`;
+          return `No match needed`;
         } else {
-          matchContent = `Unmatched`;
+          return `Unmatched`;
         }
-        /* // OLD CODE: This code is temporarily remained until the task is completed.
-        const matchUrl = '/match/' + id;
-        if (matched) {
-          matchContent = `<a class="button" href="${matchUrl}">
-            <i class="fa-solid fa-check"></i>
-            ${match_type || 'Edit'}
-          </a>`;
-        } else {
-          matchContent = `<a class="button button-primary" href="${matchUrl}">
-            <i class="fa-solid fa-circle-xmark"></i>
-            Add
-          </a>`;
-        }
-        */
-        return matchContent;
       },
 
       renderDataRow(rowData) {
@@ -87,17 +77,19 @@ modules.define(
           // details_url, // '/process/726'
           // match_url, // '/match/726'
           // match_type, // 'No direct match available'
-          matched, // false
+          // matched, // false
         } = rowData;
         const matchContent = this.renderMatchCellContent(rowData);
-        const matchUrl = '/match/' + id;
-        const matchButton = matched
-          ? `<a class="button" href="${matchUrl || ''}"><i class="fa-solid fa-check"></i> ${
-              match_type || 'EDIT'
-            }</a>`
-          : `<a class="button button-primary" href="${
-              matchUrl || ''
-            }"><i class="fa-solid fa-circle-xmark"></i> ADD</a>`;
+        /* // ORIGINAL UNUSED CODE: This code is temporarily remained until the task is completed. See code in `renderMatchCellContent`.
+         * const matchUrl = '/match/' + id;
+         * const matchButton = matched
+         *   ? `<a class="button" href="${matchUrl || ''}"><i class="fa-solid fa-check"></i> ${
+         *       match_type || 'EDIT'
+         *     }</a>`
+         *   : `<a class="button button-primary" href="${
+         *       matchUrl || ''
+         *     }"><i class="fa-solid fa-circle-xmark"></i> ADD</a>`;
+         */
         const content = `
           <tr>
             <td><div><a href="/process/${id || ''}">${name || ''}</a></div></td>

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListDataRender.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListDataRender.js
@@ -92,7 +92,9 @@ modules.define(
         const matchContent = this.renderMatchCellContent(rowData);
         const matchUrl = '/match/' + id;
         const matchButton = matched
-          ? `<a class="button" href="${matchUrl || ''}"><i class="fa-solid fa-check"></i> ${match_type || 'EDIT'}</a>`
+          ? `<a class="button" href="${matchUrl || ''}"><i class="fa-solid fa-check"></i> ${
+              match_type || 'EDIT'
+            }</a>`
           : `<a class="button button-primary" href="${
               matchUrl || ''
             }"><i class="fa-solid fa-circle-xmark"></i> ADD</a>`;

--- a/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/js/ProcessesList/ProcessesListStates.js
@@ -127,7 +127,9 @@ modules.define(
       setOrderBy(orderBy, opts = {}) {
         const { defaultOrderBy } = ProcessesListConstants;
         const rootNode = ProcessesListNodes.getRootNode();
-        const prevClass = ['order', ProcessesListData.orderBy || defaultOrderBy].filter(Boolean).join('-');
+        const prevClass = ['order', ProcessesListData.orderBy || defaultOrderBy]
+          .filter(Boolean)
+          .join('-');
         const value = orderBy || defaultOrderBy;
         const nextClass = ['order', value].filter(Boolean).join('-');
         if (prevClass !== nextClass) {
@@ -149,7 +151,9 @@ modules.define(
       setFilterBy(filterBy, opts = {}) {
         const { defaultFilterBy } = ProcessesListConstants;
         const rootNode = ProcessesListNodes.getRootNode();
-        const prevClass = ['filter', ProcessesListData.filterBy || defaultFilterBy].filter(Boolean).join('-');
+        const prevClass = ['filter', ProcessesListData.filterBy || defaultFilterBy]
+          .filter(Boolean)
+          .join('-');
         const value = filterBy || defaultFilterBy;
         const nextClass = ['filter', value].filter(Boolean).join('-');
         if (prevClass !== nextClass) {
@@ -171,7 +175,9 @@ modules.define(
       setUserDb(userDb, opts = {}) {
         const { defaultUserDb } = ProcessesListConstants;
         const rootNode = ProcessesListNodes.getRootNode();
-        const prevClass = ['filter', ProcessesListData.userDb || defaultUserDb].filter(Boolean).join('-');
+        const prevClass = ['filter', ProcessesListData.userDb || defaultUserDb]
+          .filter(Boolean)
+          .join('-');
         const value = userDb || defaultUserDb;
         const nextClass = ['filter', value].filter(Boolean).join('-');
         if (prevClass !== nextClass) {


### PR DESCRIPTION
Restored `matched` parameter, code localized in `renderMatchCellContent` method, for editors role and unmatched condition generated primary button styled link (is it neccessary?), link text generating as before (`match_type` or 'Edit' for matched row, else 'Add').

See commit [4912ec9](https://github.com/cauldron/bw_matchbox/commit/4912ec94b586a42d9593bbfbafe8334847fe693b).