### PR TITLE
Fixed #119: Added comments permissions.

### DIFF
--- a/bw_matchbox/assets/modules/@types/ThreadComments.d.ts
+++ b/bw_matchbox/assets/modules/@types/ThreadComments.d.ts
@@ -13,6 +13,8 @@ interface TThreadCommentsParams {
   disableAddNewThread?: boolean; // Disable ability to add new thread
   disableAddThreadComment?: boolean; // Disable ability to add new comment
   disableThreadResolve?: boolean; // Disable ability to resolve/resolve(open) the thread
+  disableResolveByNonReporters?: boolean; // Resolve/open function allowed only for thread reporter
+  hideDisabledTitleActions?: boolean; // Don't display disabled thread title actions
 }
 
 interface TThreadCommentsSetFilterOpts {

--- a/bw_matchbox/assets/modules/ProcessDetailPage/ProcessDetailPageInit.js
+++ b/bw_matchbox/assets/modules/ProcessDetailPage/ProcessDetailPageInit.js
@@ -69,6 +69,8 @@ export class ProcessDetailPageInit {
           // disableAddNewThread: false,
           // disableAddThreadComment: true,
           // disableThreadResolve: true,
+          disableResolveByNonReporters: true,
+          hideDisabledTitleActions: true,
         },
       );
       // Init sub-components...

--- a/bw_matchbox/assets/modules/components/ThreadComments/ThreadComments.js
+++ b/bw_matchbox/assets/modules/components/ThreadComments/ThreadComments.js
@@ -125,11 +125,15 @@ export class ThreadComments {
       disableAddNewThread,
       disableAddThreadComment,
       disableThreadResolve,
+      disableResolveByNonReporters,
+      hideDisabledTitleActions,
     } = params;
     ThreadCommentsNodes.setRootNode(rootNode);
     ThreadCommentsStates.setRole(role);
     ThreadCommentsData.currentProcess = currentProcess; // Optional
     ThreadCommentsData.currentUser = currentUser;
+    ThreadCommentsData.disableResolveByNonReporters = disableResolveByNonReporters;
+    ThreadCommentsData.hideDisabledTitleActions = hideDisabledTitleActions;
     // TODO: To duplicate those properties in the state?
     rootNode.classList.toggle('noTableau', !!noTableau);
     rootNode.classList.toggle('noLoader', !!noLoader);

--- a/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsData.js
+++ b/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsData.js
@@ -11,6 +11,13 @@ export const ThreadCommentsData = {
    */
   defaultViewParams: { ...defaultViewParams },
 
+  // Configuration (according to `TThreadCommentsParams` type, see initialization in `ThreadComments:setParams`)...
+
+  /** @type {TThreadCommentsParams["disableResolveByNonReporters"]} */
+  disableResolveByNonReporters: undefined,
+  /** @type {TThreadCommentsParams["hideDisabledTitleActions"]} */
+  hideDisabledTitleActions: undefined,
+
   // Shared params...
 
   /** @type {number} */

--- a/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsHandlers.js
+++ b/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsHandlers.js
@@ -212,6 +212,10 @@ export const ThreadCommentsHandlers = /** @lends ThreadCommentsHandlers */ {
       actionId,
       threadId,
     };
+    const isDisabled = node.classList.contains('disabled');
+    if (isDisabled) {
+      return;
+    }
     const func = apiHandlers[actionId];
     try {
       if (!func) {

--- a/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsLoader.js
+++ b/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsLoader.js
@@ -5,9 +5,10 @@ import { commonNotify } from '../../common/CommonNotify.js';
 
 import * as ThreadCommentsConstants from './ThreadCommentsConstants.js';
 import { ThreadCommentsData } from './ThreadCommentsData.js';
+import { ThreadCommentsStates } from './ThreadCommentsStates.js';
+// import { isDev } from '../../common/CommonConstants.js';
 // import { ThreadCommentsRender } from './ThreadCommentsRender.js';
 // import { ThreadCommentsPrepare } from './ThreadCommentsPrepare.js';
-import { ThreadCommentsStates } from './ThreadCommentsStates.js';
 
 export const ThreadCommentsLoader = /** @lends ThreadCommentsLoader */ {
   /* [>* @type {TEvents} <]
@@ -55,6 +56,11 @@ export const ThreadCommentsLoader = /** @lends ThreadCommentsLoader */ {
         console.log('[ThreadCommentsLoader:loadCommentsRequest]: success', {
           json,
         });
+        /* // DEBUG: Emulate 'other' reporter for the first record (Issue #119: comments-permissions)
+         * if (isDev) {
+         *   json.threads[0].reporter = 'XXX';
+         * }
+         */
         return json;
       })
       .catch((error) => {

--- a/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsRender.js
+++ b/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsRender.js
@@ -84,6 +84,41 @@ const helpers = {
    * @param {TThread} thread
    * @return {string} - HTML content
    */
+  renderThreadTitleActions(thread) {
+    const {
+      // id: threadId,
+      // resolved, // boolean, eg: false
+      // created, // TGmtDateStr, eg: 'Sat, 12 Aug 2023 12:36:08 GMT'
+      // modified, // TGmtDateStr, eg: 'Sat, 12 Aug 2023 12:36:08 GMT'
+      // name, // string, eg: 'Возмутиться кпсс гул'
+      reporter, // string, eg: '阿部 篤司'
+      // process, // TProcess;
+    } = thread;
+    const { currentUser, disableResolveByNonReporters, hideDisabledTitleActions } =
+      ThreadCommentsData;
+    const isCurrentReporter = currentUser === reporter;
+    const isResolveEnabled = !disableResolveByNonReporters || isCurrentReporter;
+    const isResolveVisible = !hideDisabledTitleActions || isResolveEnabled;
+    const actions = [
+      `<a id="threadAddComment" title="Add comment"><i class="fa-solid fa-comment"></i></a>`,
+      isResolveVisible &&
+        `<a id="threadResolve" class="${
+          !isResolveEnabled && 'disabled'
+        }"><i class="is-resolved fa-solid fa-lock" title="Resolved (click to open)"></i><i class="not-resolved fa-solid fa-lock-open" title="Open (click to resolve)"></i></a>`,
+    ].filter(Boolean);
+    console.log('[ThreadCommentsRender:helpers:renderThreadTitleActions]', {
+      actions,
+      reporter,
+      currentUser,
+      thread,
+    });
+    return actions.join('\n');
+  },
+
+  /** renderThread
+   * @param {TThread} thread
+   * @return {string} - HTML content
+   */
   renderThread(thread) {
     const {
       id: threadId,
@@ -94,6 +129,11 @@ const helpers = {
       // reporter, // string, eg: '阿部 篤司'
       // process, // TProcess;
     } = thread;
+    // const { currentUser, disableResolveByNonReporters, hideDisabledTitleActions } =
+    //   ThreadCommentsData;
+    // const isCurrentReporter = currentUser === reporter;
+    // const isResolveEnabled = !disableResolveByNonReporters || isCurrentReporter;
+    // const isResolveVisible = !hideDisabledTitleActions || isResolveEnabled;
     const isVisible = ThreadCommentsHelpers.isThreadVisible(threadId);
     const commentsList = helpers.getVisibleCommentsForThread(threadId);
     const commentPositions = commentsList.map((comment) => comment.position);
@@ -115,6 +155,7 @@ const helpers = {
       ? helpers.renderThreadCommentsContent(threadId)
       : // DEBUG: Here should be empty data for the unexpanded thread comments...
         commentPositions.join(', ');
+    const threadTitleActions = helpers.renderThreadTitleActions(thread);
     const threadTitleTextContent = helpers.createThreadTitleTextContent(thread);
     const content = `
           <div data-thread-id="${threadId}" id="thread-${threadId}" class="${className}">
@@ -129,24 +170,23 @@ const helpers = {
                   ${threadTitleTextContent}
                 </div>
                 <div class="title-actions">
-                  <a id="threadAddComment" title="Add comment"><i class="fa-solid fa-comment"></i></a>
-                  <a id="threadResolve"><i class="is-resolved fa-solid fa-lock" title="Resolved (click to open)"></i><i class="not-resolved fa-solid fa-lock-open" title="Open (click to resolve)"></i></a>
+                  ${threadTitleActions}
                 </div>
               </div>
             </div>
             <div class="comments" data-for-thread-id="${threadId}" id="comments-for-thread-${threadId}">${commentsContent}</div>
           </div>
         `;
-    /* console.log('[ThreadCommentsRender:helpers:renderThread]', {
-     *   content,
-     *   commentPositions,
-     *   threadId,
-     *   name,
-     *   reporter,
-     *   commentsList,
-     *   thread,
-     * });
-     */
+    console.log('[ThreadCommentsRender:helpers:renderThread]', {
+      content,
+      commentPositions,
+      threadId,
+      // name,
+      // reporter,
+      // currentUser,
+      commentsList,
+      thread,
+    });
     return content;
   },
 

--- a/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsRender.js
+++ b/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsRender.js
@@ -106,12 +106,13 @@ const helpers = {
           !isResolveEnabled && 'disabled'
         }"><i class="is-resolved fa-solid fa-lock" title="Resolved (click to open)"></i><i class="not-resolved fa-solid fa-lock-open" title="Open (click to resolve)"></i></a>`,
     ].filter(Boolean);
-    console.log('[ThreadCommentsRender:helpers:renderThreadTitleActions]', {
-      actions,
-      reporter,
-      currentUser,
-      thread,
-    });
+    /* console.log('[ThreadCommentsRender:helpers:renderThreadTitleActions]', {
+     *   actions,
+     *   reporter,
+     *   currentUser,
+     *   thread,
+     * });
+     */
     return actions.join('\n');
   },
 
@@ -129,11 +130,6 @@ const helpers = {
       // reporter, // string, eg: '阿部 篤司'
       // process, // TProcess;
     } = thread;
-    // const { currentUser, disableResolveByNonReporters, hideDisabledTitleActions } =
-    //   ThreadCommentsData;
-    // const isCurrentReporter = currentUser === reporter;
-    // const isResolveEnabled = !disableResolveByNonReporters || isCurrentReporter;
-    // const isResolveVisible = !hideDisabledTitleActions || isResolveEnabled;
     const isVisible = ThreadCommentsHelpers.isThreadVisible(threadId);
     const commentsList = helpers.getVisibleCommentsForThread(threadId);
     const commentPositions = commentsList.map((comment) => comment.position);
@@ -177,16 +173,17 @@ const helpers = {
             <div class="comments" data-for-thread-id="${threadId}" id="comments-for-thread-${threadId}">${commentsContent}</div>
           </div>
         `;
-    console.log('[ThreadCommentsRender:helpers:renderThread]', {
-      content,
-      commentPositions,
-      threadId,
-      // name,
-      // reporter,
-      // currentUser,
-      commentsList,
-      thread,
-    });
+    /* console.log('[ThreadCommentsRender:helpers:renderThread]', {
+     *   content,
+     *   commentPositions,
+     *   threadId,
+     *   // name,
+     *   // reporter,
+     *   // currentUser,
+     *   commentsList,
+     *   thread,
+     * });
+     */
     return content;
   },
 


### PR DESCRIPTION
The feature controlled (for now) by two `ThreadComments` configuration parameters (passing in the `setParams` method):

- `disableResolveByNonReporters` (`boolean`): Resolve/open function allowed only for thread reporter.
- `hideDisabledTitleActions` (`boolean`): Don't display disabled thread title actions.

(see `bw_matchbox/assets/modules/@types/ThreadComments.d.ts`, `TThreadCommentsParams` type).

Refactored thread rendering (extracted method for render only title actions, `ThreadCommentsRender:renderThreadTitleActions`).