### PR TITLE
Issue #143: Added panel for display recently viewed processes history.

### DIFF
--- a/bw_matchbox/assets/css/allocate-page-allocate-mode.css
+++ b/bw_matchbox/assets/css/allocate-page-allocate-mode.css
@@ -103,16 +103,11 @@
   gap: 5px;
   padding-top: 10px;
 }
-.allocate-layout .allocate-mode-layout .production-group .group-item {
-}
 .allocate-layout .allocate-mode-layout .production-group .group-item .type {
   opacity: 0.5;
 }
 
 /* Collapsed/expanded group items */
-.allocate-layout .allocate-mode-layout .production-group .empty {
-  /* opacity: .5; */
-}
 .allocate-layout .allocate-mode-layout .production-group .action:not(.disabled) {
   transition: all var(--common-animation-time);
   /* opacity: 0.6; */

--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -7,6 +7,7 @@
   /* Error color */
   --layout-theme-common-error-color: #c33;
   /* Animations */
+  --common-transition-time: 150ms;
   --common-animation-time: 250ms;
   --common-effect-time: 500ms;
   /* Main colors */
@@ -129,12 +130,6 @@
   font-weight: normal;
 }
 
-/* Panels layout */
-/* TODO: Make width adaptive depending on the screen size? */
-.panels-layout-side.hidden {
-  display: none;
-}
-
 /* Panels layout actions */
 .panels-layout .panels-layout-actions {
   position: absolute;
@@ -190,7 +185,18 @@
   padding: 20px;
 }
 
+/* Panels layout */
+/* TODO: Make width adaptive depending on the screen size? */
+.panels-layout-side.hidden {
+  /* display: none; */
+}
+
 /* TODO: To use vars for media queries? Eg, for `panels-layout-min-threshold`? */
+@media (width < 700px) {
+  .panels-layout-side.hidden {
+    display: none;
+  }
+}
 @media (width >= 700px) {
   .panels-layout-container.padded {
     padding: 20px;
@@ -239,7 +245,7 @@
     flex: 1;
   }
   .panels-layout-side {
-    transition: all 1s;
+    transition: all var(--common-animation-time) ease-out;
     width: var(--panels-layout-side-panel-width);
     flex-shrink: 0;
     opacity: 1;

--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -25,6 +25,8 @@
   --panels-layout-actions-offset: 20px;
   --panels-layout-actions-offset-y: 10px;
   --minor-border-color: #eee;
+  /** Comments */
+  --comments-actions-button-size: 24px;
 }
 
 /* Basic layout */
@@ -174,11 +176,18 @@
 .panels-layout .panels-layout-actions-button.turnaround.turned {
   transform: rotate(90deg);
 }
+.panels-layout-content {
+  flex: 1;
+}
 .panels-layout-content.padded {
   margin: 20px auto;
 }
 .panels-layout-side:not(.hidden) {
   border-bottom: 1px solid var(--minor-border-color);
+}
+
+.panels-layout-container.padded {
+  padding: 20px;
 }
 
 /* TODO: To use vars for media queries? Eg, for `panels-layout-min-threshold`? */

--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -161,6 +161,13 @@
 .panels-layout .panels-layout-actions-button:hover {
   opacity: 1;
 }
+.panels-layout .panels-layout-actions-button.activable > * {
+  transition: all var(--common-animation-time);
+}
+.panels-layout .panels-layout-actions-button.activable.active > .icon-default,
+.panels-layout .panels-layout-actions-button.activable:not(.active) > .icon-active {
+  display: none;
+}
 .panels-layout .panels-layout-actions-button.turnaround {
   transform: rotate(-90deg);
 }
@@ -208,10 +215,6 @@
     align-items: stretch;
     justify-content: stretch;
     /* flex-direction: row-reverse; */
-  }
-  .panels-layout-side.hidden,
-  .panels-layout-side {
-    display: block;
   }
   .panels-layout-main,
   .panels-layout-side {

--- a/bw_matchbox/assets/css/process-detail.css
+++ b/bw_matchbox/assets/css/process-detail.css
@@ -22,7 +22,7 @@
   /* XXX: Can be disabed temporarily */
   display: none;
 }
-.panels-layout .thread-comments-panel {
+.panels-layout .thread-comments-panel:not(.hidden) {
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -4,6 +4,11 @@
     selector-class-pattern,
 */
 
+/* Wrapper fixups */
+.processes-list-layout #recent-processes-panel .recent-processes {
+  flex: 1;
+}
+
 /* Root node */
 .processes-list {
   margin-bottom: 20px;

--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -8,6 +8,16 @@
 .processes-list-layout #recent-processes-panel .recent-processes {
   flex: 1;
 }
+.processes-list-layout {
+  opacity: 0.5;
+  transition: all var(--common-animation-time);
+}
+.processes-list-layout.inited {
+  opacity: 1;
+}
+.processes-list-layout:not(.inited) .panels-layout-actions {
+  display: none;
+}
 
 /* Root node */
 .processes-list {

--- a/bw_matchbox/assets/css/recent-processes.css
+++ b/bw_matchbox/assets/css/recent-processes.css
@@ -11,9 +11,15 @@
 
 .recent-processes-container {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 16px;
+  flex: 1;
 }
 
 .recent-processes-container .recent-processes-list-tableau {
+  flex: 1;
   position: relative;
   min-height: 40px; /* Ensure space for loading splash */
 }
@@ -28,6 +34,7 @@
 
 /* Empty state: hide some elements... */
 .recent-processes-container.empty .recent-processes-list,
+.recent-processes-container.empty .recent-processes-list-title,
 .recent-processes-container.loading .recent-processes-list-empty,
 .recent-processes-container:not(.empty) .recent-processes-list-empty,
 .recent-processes-container.has-visible-threads .recent-processes-list-empty {
@@ -118,9 +125,14 @@
 }
 
 /* List... */
-.recent-process-item {
+.recent-processes-container .recent-processes-list-title {
+  /* color: var(--layout-theme-primary-color); */
+  font-size: 120%;
 }
-.recent-process-item a {
+.recent-processes-container .recent-processes-list {
+  margin: 0 -8px;
+}
+.recent-processes-container .recent-processes-list .recent-process-item a {
   margin: 2px 0;
   padding: 4px 8px;
   border-radius: 4px;
@@ -129,10 +141,10 @@
   display: block;
   text-decoration: none;
 }
-.recent-process-item a:hover {
+.recent-processes-container .recent-processes-list .recent-process-item a:hover {
   background-color: var(--primary-bg-color1);
   text-decoration: underline;
 }
-.recent-process-item .date {
+.recent-processes-container .recent-processes-list .recent-process-item .date {
   opacity: 0.5;
 }

--- a/bw_matchbox/assets/css/recent-processes.css
+++ b/bw_matchbox/assets/css/recent-processes.css
@@ -1,0 +1,138 @@
+/* stylelint-disable selector-id-pattern, selector-class-pattern */
+
+.recent-processes-container {
+  --primary-bg-color05: rgb(30 174 219 / 5%);
+  --primary-bg-color1: rgb(30 174 219 / 10%);
+  --primary-bg-color2: rgb(30 174 219 / 20%);
+  --primary-bg-color3: rgb(30 174 219 / 30%);
+  --primary-bg-color4: rgb(30 174 219 / 40%);
+  --primary-bg-color5: rgb(30 174 219 / 50%);
+}
+
+.recent-processes-container {
+  position: relative;
+}
+
+.recent-processes-container .recent-processes-list-tableau {
+  position: relative;
+  min-height: 40px; /* Ensure space for loading splash */
+}
+.recent-processes-container.noTableau .recent-processes-list-tableau {
+  display: none;
+}
+
+/* Basic rules... */
+.recent-processes-container > * {
+  transition: all var(--common-animation-time);
+}
+
+/* Empty state: hide some elements... */
+.recent-processes-container.empty .recent-processes-list,
+.recent-processes-container.loading .recent-processes-list-empty,
+.recent-processes-container:not(.empty) .recent-processes-list-empty,
+.recent-processes-container.has-visible-threads .recent-processes-list-empty {
+  display: none;
+}
+.recent-processes-container .recent-processes-list-empty {
+  padding: 10px;
+  margin: 10px auto;
+  text-align: center;
+  opacity: 0.5;
+}
+
+/** Loading elements */
+.recent-processes-container.loading .recent-processes-list,
+.recent-processes-container.loading .recent-processes-list-empty {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* Actions */
+.recent-processes-container.noActions .recent-processes-list-actions {
+  display: none;
+}
+.recent-processes-container .recent-processes-list-actions {
+  border-radius: 4px;
+  padding: 4px 8px;
+  background-color: rgba(0 0 0 / 5%);
+}
+.recent-processes-container .recent-processes-list-actions a {
+  font-size: 0.9em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: var(--comments-actions-button-size);
+  height: var(--comments-actions-button-size);
+  border-radius: 4px;
+  opacity: 0.5;
+}
+/* Some particular icons' fixes */
+.recent-processes-container .recent-processes-list-actions a#addNewThread i {
+  margin-top: 3px;
+}
+.recent-processes-container .recent-processes-list-actions a.disabled {
+  color: #ddd;
+  cursor: default;
+}
+.recent-processes-container .recent-processes-list-actions a:not(.disabled) {
+  transition: all var(--common-animation-time);
+  cursor: pointer;
+}
+.recent-processes-container .thread:hover .title-actions a:not(.disabled) {
+  color: var(--layout-theme-primary-color);
+}
+.recent-processes-container .recent-processes-list-actions a:not(.disabled):active,
+.recent-processes-container .recent-processes-list-actions a:not(.disabled):hover {
+  opacity: 1;
+}
+.recent-processes-container .recent-processes-list-actions a:not(.disabled):active {
+  background-color: var(--layout-theme-primary-color);
+  box-shadow: 0 0 4px 2px var(--layout-theme-primary-color);
+  color: #fff;
+}
+
+/* Loader splash */
+.recent-processes-container.noError .loader-splash {
+  display: none;
+}
+.recent-processes-container .loader-splash {
+  padding: 20px;
+}
+.recent-processes-container:not(.loading) .loader-splash {
+  /* Inherited from `.loader-splash.hidden`, see `bw_matchbox/assets/css/common.css` */
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Error */
+.recent-processes-container .error {
+  border-radius: 4px;
+  background-color: var(--common-error-color);
+  color: #fff;
+  margin: 20px auto;
+  padding: 10px 20px;
+}
+.recent-processes-container.noError .error,
+.recent-processes-container:not(.has-error) .error {
+  display: none;
+}
+
+/* List... */
+.recent-process-item {
+}
+.recent-process-item a {
+  margin: 2px 0;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: all var(--common-animation-time);
+  line-height: 1.3;
+  display: block;
+  text-decoration: none;
+}
+.recent-process-item a:hover {
+  background-color: var(--primary-bg-color1);
+  text-decoration: underline;
+}
+.recent-process-item .date {
+  opacity: 0.5;
+}

--- a/bw_matchbox/assets/css/thread-comments.css
+++ b/bw_matchbox/assets/css/thread-comments.css
@@ -1,9 +1,5 @@
 /* stylelint-disable selector-id-pattern, selector-class-pattern */
 
-:root {
-  --comments-actions-button-size: 24px;
-}
-
 .thread-comments {
   position: relative;
 }

--- a/bw_matchbox/assets/modules/@types/TRecentProcesses.d.ts
+++ b/bw_matchbox/assets/modules/@types/TRecentProcesses.d.ts
@@ -1,6 +1,7 @@
 interface TRecentProcess {
   id: number;
-  name: string; // TODO: Is it neccessary to store name? Can we get name by id without extra requests on the frontend side?
-  timestamp: number;
+  // NOTE: The name shouldn't be stored in cookie. We can get it from server with `loadProcessesAttributes`.
+  name?: string;
+  time: number;
 }
 type TRecentProcesses = TRecentProcess[];

--- a/bw_matchbox/assets/modules/@types/TRecentProcesses.d.ts
+++ b/bw_matchbox/assets/modules/@types/TRecentProcesses.d.ts
@@ -1,6 +1,6 @@
-interface TStoredProcess {
+interface TRecentProcess {
   id: number;
   name: string; // TODO: Is it neccessary to store name? Can we get name by id without extra requests on the frontend side?
   timestamp: number;
 }
-type TStoredProcesses = TStoredProcess[];
+type TRecentProcesses = TRecentProcess[];

--- a/bw_matchbox/assets/modules/@types/TStoredProcesses.d.ts
+++ b/bw_matchbox/assets/modules/@types/TStoredProcesses.d.ts
@@ -1,0 +1,6 @@
+interface TStoredProcess {
+  id: number;
+  name: string; // TODO: Is it neccessary to store name? Can we get name by id without extra requests on the frontend side?
+  timestamp: number;
+}
+type TStoredProcesses = TStoredProcess[];

--- a/bw_matchbox/assets/modules/common/CommonConstants.js
+++ b/bw_matchbox/assets/modules/common/CommonConstants.js
@@ -26,3 +26,6 @@ export const dateTimeFormatOptions = {
   minute: 'numeric',
   // second: 'numeric',
 };
+
+/** Timestamp ticks for one day (24 hours) */
+export const dailyTicks = 24 * 60 * 60 * 1000;

--- a/bw_matchbox/assets/modules/common/CommonConstants.js
+++ b/bw_matchbox/assets/modules/common/CommonConstants.js
@@ -29,3 +29,12 @@ export const dateTimeFormatOptions = {
 
 /** Timestamp ticks for one day (24 hours) */
 export const dailyTicks = 24 * 60 * 60 * 1000;
+
+/** The count of actual process records to store (0 - use all the records) */
+export const storeRecentProcessesCount = 10;
+
+/** Days to keep actual recent process records (0 don't actualize by time) */
+export const storeRecentProcessesForDays = 0;
+
+/** Cookie name to store recent process list */
+export const storeRecentProcessesCookieName = 'recent-processes';

--- a/bw_matchbox/assets/modules/common/CommonCookies.js
+++ b/bw_matchbox/assets/modules/common/CommonCookies.js
@@ -23,6 +23,14 @@ export function setCookie(name, value, days) {
     .filter(Boolean)
     .join('; ');
   document.cookie = cookie;
+  /* console.log('[CommonCookies:setCookie]', {
+   *   cookie,
+   *   name,
+   *   value,
+   *   days,
+   *   cookies: document.cookie,
+   * });
+   */
 }
 
 /**

--- a/bw_matchbox/assets/modules/common/CommonCookies.js
+++ b/bw_matchbox/assets/modules/common/CommonCookies.js
@@ -1,0 +1,53 @@
+// @ts-check
+
+import { dailyTicks } from './CommonConstants.js';
+
+/**
+ * @param {string} name
+ * @param {string} [value]
+ * @param {number} [days]
+ */
+export function setCookie(name, value, days) {
+  let expires = '';
+  if (days) {
+    const date = new Date();
+    date.setTime(date.getTime() + days * dailyTicks);
+    expires = 'expires=' + date.toUTCString();
+  }
+  const cookie = [
+    // prettier-ignore
+    name + '=' + (value || ''),
+    expires,
+    'path=/',
+  ]
+    .filter(Boolean)
+    .join('; ');
+  document.cookie = cookie;
+}
+
+/**
+ * @param {string} name
+ * @return {string | undefined}
+ */
+export function getCookie(name) {
+  const nameEQ = name + '=';
+  const ca = document.cookie.split(';');
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    // TODO: Use `trim`?
+    while (c.charAt(0) == ' ') {
+      c = c.substring(1, c.length);
+    }
+    if (c.indexOf(nameEQ) == 0) {
+      return c.substring(nameEQ.length, c.length);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * @param {string} name
+ */
+export function eraseCookie(name) {
+  document.cookie = name + '=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+}

--- a/bw_matchbox/assets/modules/common/RecentProcesses.js
+++ b/bw_matchbox/assets/modules/common/RecentProcesses.js
@@ -1,20 +1,12 @@
 // @ts-check
 
-import { dailyTicks } from './CommonConstants.js';
+import {
+  dailyTicks,
+  storeRecentProcessesCount,
+  storeRecentProcessesForDays,
+  storeRecentProcessesCookieName,
+} from './CommonConstants.js';
 import { getCookie, setCookie } from './CommonCookies.js';
-
-/* TODO:
- * - 2023.11.20, 17:10 -- To store process names in local storage instead of cookies?
- */
-
-/** The count of actual process records to store (0 - use all the records) */
-const actualCount = 20;
-
-/** Days to keep actual records (0 don't actualize by time) */
-const actualDays = 10;
-
-/** Cookie name to store process list */
-const cookieName = 'recent-processes';
 
 /** Helper function to sort processes by time (the latest entries are first)
  * @param {TRecentProcess} a
@@ -35,24 +27,25 @@ function sortRecentProcesses(processesList) {
   return processesList;
 }
 
-/** Actualize processes list (remain {actualCount} last records for {actualDays} last days)
+/** Actualize processes list (remain {storeRecentProcessesCount} last records for {storeRecentProcessesForDays} last days)
  * @param {TRecentProcesses} sortedList - Processes list should be sorted by date first
  * @return {TRecentProcesses}
  */
 function actualizeRecentProcecess(sortedList) {
   // Filter out outdated records...
   const actualizedList = [];
-  const earliestValidTimestamp = actualDays && Date.now() - dailyTicks * actualDays;
+  const earliestValidTimestamp =
+    storeRecentProcessesForDays && Date.now() - dailyTicks * storeRecentProcessesForDays;
   for (
     let i = 0;
     i < sortedList.length &&
     // Actualize by time if specified...
-    (!actualCount || actualizedList.length < actualCount);
+    (!storeRecentProcessesCount || actualizedList.length < storeRecentProcessesCount);
     i++
   ) {
     const item = sortedList[i];
     // If dated later than earliest valid time...
-    if (!actualDays || !item.time || item.time > earliestValidTimestamp) {
+    if (!storeRecentProcessesForDays || !item.time || item.time > earliestValidTimestamp) {
       actualizedList.push(item);
     }
   }
@@ -63,7 +56,7 @@ function actualizeRecentProcecess(sortedList) {
  * @return {TRecentProcesses}
  */
 export function getRecentProcesses() {
-  const json = getCookie(cookieName);
+  const json = getCookie(storeRecentProcessesCookieName);
   const processesList = /** @type {TRecentProcesses} */ (json ? JSON.parse(json) : []);
   return processesList;
 }
@@ -142,7 +135,7 @@ export function storeProcess(id) {
    */
   // Save cookie...
   const json = JSON.stringify(actualizedList);
-  setCookie(cookieName, json);
+  setCookie(storeRecentProcessesCookieName, json);
   // Return the updated list...
   return actualizedList;
 }

--- a/bw_matchbox/assets/modules/common/RecentProcesses.js
+++ b/bw_matchbox/assets/modules/common/RecentProcesses.js
@@ -16,16 +16,16 @@ const actualDays = 10;
 /** Cookie name to store process list */
 const cookieName = 'recent-processes';
 
-/** Helper function to sort processes by timestamp (the latest entries are first)
+/** Helper function to sort processes by time (the latest entries are first)
  * @param {TRecentProcess} a
  * @param {TRecentProcess} b
  * @return number
  */
 function sortProcessItemsByTimestampIterator(a, b) {
-  return b.timestamp - a.timestamp;
+  return b.time - a.time;
 }
 
-/** Sort processes list by timestamp.
+/** Sort processes list by time.
  * @param {TRecentProcesses} processesList
  * @return {TRecentProcesses}
  */
@@ -51,8 +51,8 @@ function actualizeRecentProcecess(sortedList) {
     i++
   ) {
     const item = sortedList[i];
-    // If dated later than earliest valid timestamp...
-    if (!actualDays || !item.timestamp || item.timestamp > earliestValidTimestamp) {
+    // If dated later than earliest valid time...
+    if (!actualDays || !item.time || item.time > earliestValidTimestamp) {
       actualizedList.push(item);
     }
   }
@@ -90,21 +90,18 @@ export function getActualSortedRecentProcesses() {
 
 /** Add or update process
  * @param {number} id
- * @param {string} name
  * @return {TRecentProcesses}
  */
-export function storeProcess(id, name) {
+export function storeProcess(id) {
   /** @type TRecentProcess */
   const record = {
     id,
-    name,
-    timestamp: Date.now(),
+    time: Date.now(),
   };
   const processesList = getRecentProcesses();
   /* console.log('[RecentProcesses:storeProcess] start', {
    *   record,
    *   id,
-   *   name,
    *   processesList,
    * });
    */
@@ -119,7 +116,6 @@ export function storeProcess(id, name) {
        *   item,
        *   record,
        *   id,
-       *   name,
        *   processesList,
        * });
        */
@@ -132,7 +128,6 @@ export function storeProcess(id, name) {
     /* console.log('[RecentProcesses:storeProcess] add new record', {
      *   record,
      *   id,
-     *   name,
      *   processesList,
      * });
      */
@@ -140,6 +135,11 @@ export function storeProcess(id, name) {
   }
   // Actualize the list...
   const actualizedList = sortAndActualizeRecentProcesses(updatedProcesses);
+  /* console.log('[RecentProcesses:storeProcess] store actualized list', {
+   *   id,
+   *   actualizedList,
+   * });
+   */
   // Save cookie...
   const json = JSON.stringify(actualizedList);
   setCookie(cookieName, json);

--- a/bw_matchbox/assets/modules/common/StoredProcesses.js
+++ b/bw_matchbox/assets/modules/common/StoredProcesses.js
@@ -1,0 +1,147 @@
+// @ts-check
+
+import { dailyTicks } from './CommonConstants.js';
+import { getCookie, setCookie } from './CommonCookies.js';
+
+/* TODO:
+ * - 2023.11.20, 17:10 -- To store process names in local storage instead of cookies?
+ */
+
+/** The count of actual process records to store (0 - use all the records) */
+const actualCount = 20;
+
+/** Days to keep actual records (0 don't actualize by time) */
+const actualDays = 10;
+
+/** Cookie name to store process list */
+const cookieName = 'ProcessesList';
+
+/** Helper functiuon to sort processes
+ * @param {TStoredProcess} a
+ * @param {TStoredProcess} b
+ * @return number
+ */
+function sortProcessItemsByTimestampIterator(a, b) {
+  return b.timestamp - a.timestamp;
+}
+
+/** Sort processes list by timestamp.
+ * @param {TStoredProcesses} processesList
+ * @return {TStoredProcesses}
+ */
+function sortStoredProcesses(processesList) {
+  // const cloned = [...processesList];
+  processesList.sort(sortProcessItemsByTimestampIterator);
+  return processesList;
+}
+
+/** Actualize processes list (remain {actualCount} last records for {actualDays} last days)
+ * @param {TStoredProcesses} sortedList - Processes list should be sorted by date first
+ * @return {TStoredProcesses}
+ */
+function actualizeStoredProcecces(sortedList) {
+  // Filter out outdated records...
+  const actualizedList = [];
+  const earliestValidTimestamp = actualDays && Date.now() - dailyTicks * actualDays;
+  for (
+    let i = 0;
+    i < sortedList.length &&
+    // Actualize by time if specified...
+    (!actualCount || actualizedList.length < actualCount);
+    i++
+  ) {
+    const item = sortedList[i];
+    // If dated later than earliest valid timestamp...
+    if (!actualDays || !item.timestamp || item.timestamp > earliestValidTimestamp) {
+      actualizedList.push(item);
+    }
+  }
+  return actualizedList;
+}
+
+/** Get all stored processes.
+ * @return {TStoredProcesses}
+ */
+export function getStoredProcesses() {
+  const json = getCookie(cookieName);
+  const processesList = /** @type {TStoredProcesses} */ (json ? JSON.parse(json) : []);
+  return processesList;
+}
+
+/** Get all stored processes.
+ * @param {TStoredProcesses} processesList
+ * @return {TStoredProcesses}
+ */
+function sortAndActualizeStoredProcesses(processesList) {
+  const clonedList = [...processesList];
+  // Sort and actualize records (remove outdated ones)?
+  sortStoredProcesses(clonedList);
+  const actualizedList = actualizeStoredProcecces(clonedList);
+  return actualizedList;
+}
+/** Get all stored processes.
+ * @return {TStoredProcesses}
+ */
+export function getActualSortedStoredProcesses() {
+  const processesList = getStoredProcesses();
+  const actualizedList = sortAndActualizeStoredProcesses(processesList);
+  return actualizedList;
+}
+
+/** Add or update process
+ * @param {number} id
+ * @param {string} name
+ * @return {TStoredProcesses}
+ */
+export function storeProcess(id, name) {
+  /** @type TStoredProcess */
+  const record = {
+    id,
+    name,
+    timestamp: Date.now(),
+  };
+  const processesList = getStoredProcesses();
+  /* console.log('[StoredProcesses:storeProcess] start', {
+   *   record,
+   *   id,
+   *   name,
+   *   processesList,
+   * });
+   */
+  let alreadyUpdated = false;
+  // Update record in the list (if exists)...
+  const updatedProcesses = processesList.map((item) => {
+    if (item.id === id) {
+      // Record has already existed...
+      alreadyUpdated = true;
+      /* console.log('[StoredProcesses:storeProcess] replace record', {
+       *   item,
+       *   record,
+       *   id,
+       *   name,
+       *   processesList,
+       * });
+       */
+      return record;
+    }
+    return item;
+  });
+  // Otherwise add the item into the list...
+  if (!alreadyUpdated) {
+    /* console.log('[StoredProcesses:storeProcess] add new record', {
+     *   record,
+     *   id,
+     *   name,
+     *   processesList,
+     * });
+     */
+    updatedProcesses.unshift(record);
+  }
+  // Actualize the list...
+  const actualizedList = sortAndActualizeStoredProcesses(updatedProcesses);
+  // Save cookie...
+  const json = JSON.stringify(actualizedList);
+  setCookie(cookieName, json);
+  // Return the updated list...
+  return actualizedList;
+}

--- a/bw_matchbox/assets/modules/components/RecentProcesses/@types/TProcessAttributes.d.ts
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/@types/TProcessAttributes.d.ts
@@ -1,0 +1,9 @@
+interface TProcessAttributes {
+  id: number; // 28189
+  database: string; // 'uvek-2022'
+  location: string; // 'HU'
+  name: string; // 'disposal, lignite ash, 0% water, to opencast refill'
+  product: string; // 'disposal, lignite ash, 0% water, to opencast refill'
+  unit: string; // 'kilogram'
+  url: string; // '/process/28189'
+}

--- a/bw_matchbox/assets/modules/components/RecentProcesses/@types/TRecentProcessesListInitParams.d.ts
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/@types/TRecentProcessesListInitParams.d.ts
@@ -1,0 +1,9 @@
+interface TRecentProcessesListInitParams {
+  handlers: TSharedHandlers;
+  events: SimpleEvents;
+  recentProcessesListRender: RecentProcessesListRender;
+  recentProcessesListNodes: RecentProcessesListNodes;
+  // recentProcessesListHandlers: RecentProcessesListHandlers;
+  // recentProcessesListStates: RecentProcessesListStates;
+  // recentProcessesListPrepare: RecentProcessesListPrepare;
+}

--- a/bw_matchbox/assets/modules/components/RecentProcesses/@types/TRecentProcessesListParams.d.ts
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/@types/TRecentProcessesListParams.d.ts
@@ -1,0 +1,8 @@
+/** Possible parameters for externally configuring of the component */
+interface TRecentProcessesListParams {
+  rootNode: Element;
+  noTableau?: boolean; // Do not show tableau block
+  noLoader?: boolean; // Do not show inner loader
+  noError?: boolean; // Do not show inner error block
+  noActions?: boolean; // Disable actions panel
+}

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesList.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesList.js
@@ -1,0 +1,97 @@
+// @ts-check
+
+import { RecentProcessesListNodes } from './RecentProcessesListNodes.js';
+import { RecentProcessesListData } from './RecentProcessesListData.js';
+import { RecentProcessesListInit } from './RecentProcessesListInit.js';
+import { RecentProcessesListRender } from './RecentProcessesListRender.js';
+import { RecentProcessesListApi } from './RecentProcessesListApi.js';
+// import { RecentProcessesListStates } from './RecentProcessesListStates.js';
+// import { RecentProcessesListHandlers } from './RecentProcessesListHandlers.js';
+// import { RecentProcessesListPrepare } from './RecentProcessesListPrepare.js';
+
+/*-- @implements {TRecentProcessesList} */
+export class RecentProcessesList {
+  /** @type {RecentProcessesListInit} */
+  recentProcessesListInit = undefined;
+
+  /** Technical (debug) id
+   * @type {string}
+   */
+  thisId = 'RecentProcessesList';
+
+  /** @type {TSharedHandlers} */
+  handlers = {};
+
+  /* @type {RecentProcessesListRender} */
+  recentProcessesListRender = new RecentProcessesListRender();
+
+  /** @type {TEvents} */
+  events = undefined;
+
+  // TODO: state, data?
+
+  /** External API (alternate way, basic handlers are in `handlers` object (above)...
+   * @type {RecentProcessesListApi}
+   */
+  api;
+
+  /** @param {string} parentId */
+  constructor(parentId) {
+    if (parentId) {
+      const thisId = [parentId, 'RecentProcessesList'].filter(Boolean).join('_');
+      this.thisId = thisId;
+    }
+    const recentProcessesListApi = new RecentProcessesListApi({
+      recentProcessesListData: RecentProcessesListData,
+      recentProcessesListNodes: RecentProcessesListNodes,
+      recentProcessesListRender: this.recentProcessesListRender,
+      // recentProcessesListHandlers: RecentProcessesListHandlers,
+      // recentProcessesListStates: RecentProcessesListStates,
+      // recentProcessesListPrepare: RecentProcessesListPrepare,
+    });
+    this.api = recentProcessesListApi;
+    const { handlers } = this;
+    this.recentProcessesListInit = new RecentProcessesListInit({
+      handlers,
+      parentId: this.thisId,
+      recentProcessesListRender: this.recentProcessesListRender,
+      recentProcessesListNodes: RecentProcessesListNodes,
+      // recentProcessesListStates: RecentProcessesListStates,
+      // recentProcessesListHandlers: RecentProcessesListHandlers,
+      // recentProcessesListPrepare: RecentProcessesListPrepare,
+    });
+    this.events = this.recentProcessesListInit.events();
+  }
+
+  /** Ensure the modal has initiazlized
+   * @return {Promise}
+   */
+  ensureInit() {
+    return this.recentProcessesListInit.ensureInit();
+  }
+
+  /** Initialize the longest things (loading external css styles)
+   */
+  preInit() {
+    return this.recentProcessesListInit.preInit();
+  }
+
+  /** Should be called before initalization
+   * @param {TRecentProcessesListParams} params
+   */
+  setParams(params) {
+    const {
+      // Parameters..
+      rootNode,
+      noTableau,
+      noLoader,
+      noError,
+      noActions,
+    } = params;
+    RecentProcessesListNodes.setRootNode(rootNode);
+    rootNode.classList.toggle('noTableau', !!noTableau);
+    rootNode.classList.toggle('noLoader', !!noLoader);
+    rootNode.classList.toggle('noError', !!noError);
+    rootNode.classList.toggle('noActions', !!noActions);
+  }
+}

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesList.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesList.js
@@ -5,7 +5,8 @@ import { RecentProcessesListData } from './RecentProcessesListData.js';
 import { RecentProcessesListInit } from './RecentProcessesListInit.js';
 import { RecentProcessesListRender } from './RecentProcessesListRender.js';
 import { RecentProcessesListApi } from './RecentProcessesListApi.js';
-// import { RecentProcessesListStates } from './RecentProcessesListStates.js';
+import { RecentProcessesListLoader } from './RecentProcessesListLoader.js';
+import { RecentProcessesListStates } from './RecentProcessesListStates.js';
 // import { RecentProcessesListHandlers } from './RecentProcessesListHandlers.js';
 // import { RecentProcessesListPrepare } from './RecentProcessesListPrepare.js';
 
@@ -45,8 +46,8 @@ export class RecentProcessesList {
       recentProcessesListData: RecentProcessesListData,
       recentProcessesListNodes: RecentProcessesListNodes,
       recentProcessesListRender: this.recentProcessesListRender,
-      // recentProcessesListHandlers: RecentProcessesListHandlers,
-      // recentProcessesListStates: RecentProcessesListStates,
+      recentProcessesListLoader: RecentProcessesListLoader,
+      recentProcessesListStates: RecentProcessesListStates,
       // recentProcessesListPrepare: RecentProcessesListPrepare,
     });
     this.api = recentProcessesListApi;
@@ -56,7 +57,7 @@ export class RecentProcessesList {
       parentId: this.thisId,
       recentProcessesListRender: this.recentProcessesListRender,
       recentProcessesListNodes: RecentProcessesListNodes,
-      // recentProcessesListStates: RecentProcessesListStates,
+      recentProcessesListStates: RecentProcessesListStates,
       // recentProcessesListHandlers: RecentProcessesListHandlers,
       // recentProcessesListPrepare: RecentProcessesListPrepare,
     });

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListApi.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListApi.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+import { getActualSortedRecentProcesses } from '../../common/RecentProcesses.js';
+
+// Import types only...
+/* eslint-disable no-unused-vars */
+import { RecentProcessesListData } from './RecentProcessesListData.js';
+// import { RecentProcessesListHandlers } from './RecentProcessesListHandlers.js';
+import { RecentProcessesListNodes } from './RecentProcessesListNodes.js';
+import { RecentProcessesListRender } from './RecentProcessesListRender.js';
+/* eslint-enable no-unused-vars */
+
+/* External API (alternate way, basic handlers are in `handlers` object (above)...
+ * @implements {TRecentProcessesListApi}
+ */
+export class RecentProcessesListApi {
+  /** @type {RecentProcessesListData} */
+  recentProcessesListData;
+  // [>* @type {RecentProcessesListHandlers} <]
+  // recentProcessesListHandlers;
+  /** @type {RecentProcessesListNodes} */
+  recentProcessesListNodes;
+  /** @type {RecentProcessesListRender} */
+  recentProcessesListRender;
+
+  /**
+   * @param {object} params
+   * @param {RecentProcessesListData} params.recentProcessesListData
+   * --param {RecentProcessesListHandlers} params.recentProcessesListHandlers
+   * @param {RecentProcessesListNodes} params.recentProcessesListNodes
+   * @param {RecentProcessesListRender} params.recentProcessesListRender
+   */
+  constructor(params) {
+    const {
+      // prettier-ignore
+      recentProcessesListData,
+      // recentProcessesListHandlers,
+      recentProcessesListNodes,
+      recentProcessesListRender,
+    } = params;
+    this.recentProcessesListData = recentProcessesListData;
+    // this.recentProcessesListHandlers = recentProcessesListHandlers;
+    this.recentProcessesListNodes = recentProcessesListNodes;
+    this.recentProcessesListRender = recentProcessesListRender;
+  }
+
+  getRecentProcesses() {
+    return this.recentProcessesListData.recentProcesses;
+  }
+
+  loadData() {
+    const rootNode = this.recentProcessesListNodes.getRootNode();
+    rootNode.classList.toggle('loading', true);
+    const recentProcesses = getActualSortedRecentProcesses();
+    this.recentProcessesListData.recentProcesses = recentProcesses;
+    // TODO: Extend data (with methods from `RecentProcessesListPrepare`), eg to add names to items
+    // TODO: Invoke events to re-render content?
+    this.recentProcessesListRender.renderData();
+    // Set dafault classes...
+    rootNode.classList.toggle('loading', false);
+    rootNode.classList.toggle('empty', !recentProcesses.length);
+    rootNode.classList.toggle('dataReady', true);
+  }
+}

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListConstants.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListConstants.js
@@ -1,0 +1,4 @@
+// @ts-check
+
+/** Api base */
+export {};

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListConstants.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListConstants.js
@@ -1,4 +1,4 @@
 // @ts-check
 
 /** Api base */
-export {};
+export const processesAttributesApiUrl = '/processes-attributes-json/';

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListData.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListData.js
@@ -1,0 +1,13 @@
+// @ts-check
+
+export const RecentProcessesListData = {
+  // Data...
+  /** @type {TRecentProcesses} */
+  recentProcesses: [],
+
+  // Common params...
+  error: undefined,
+  isError: false,
+  isLoading: true,
+  hasData: false,
+};

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListHelpers.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListHelpers.js
@@ -1,5 +1,22 @@
 // @ts-check
 
 export const RecentProcessesListHelpers = {
-  // TODO
+  /** Extend processes data with dattributes data
+   * @param {TRecentProcesses} recentProcesses
+   * @param {TProcessAttributes[]} processesAttributes
+   * @return {TRecentProcesses} - Returns updated processes data
+   */
+  extendRecentProcessesWithAttributes(recentProcesses, processesAttributes) {
+    /** @type {Map<number, TProcessAttributes>} */
+    const attrsMap = new Map();
+    processesAttributes.forEach((attrs) => attrsMap.set(attrs.id, attrs));
+    const updatedProcesses = recentProcesses.map((item) => {
+      const attrs = attrsMap.get(item.id);
+      if (attrs && attrs.name) {
+        return { ...item, name: attrs.name };
+      }
+      return item;
+    });
+    return updatedProcesses;
+  },
 };

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListHelpers.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListHelpers.js
@@ -1,0 +1,5 @@
+// @ts-check
+
+export const RecentProcessesListHelpers = {
+  // TODO
+};

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListInit.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListInit.js
@@ -4,8 +4,8 @@
 /* eslint-disable no-unused-vars */
 import { RecentProcessesListRender } from './RecentProcessesListRender.js';
 import { RecentProcessesListNodes } from './RecentProcessesListNodes.js';
+import { RecentProcessesListStates } from './RecentProcessesListStates.js';
 // import { RecentProcessesListHandlers } from './RecentProcessesListHandlers.js';
-// import { RecentProcessesListStates } from './RecentProcessesListStates.js';
 // import { RecentProcessesListPrepare } from './RecentProcessesListPrepare.js';
 /* eslint-enable no-unused-vars */
 
@@ -55,6 +55,7 @@ export class RecentProcessesListInit {
    * @param {string} [params.parentId]
    * @param {RecentProcessesListRender} params.recentProcessesListRender
    * @param {RecentProcessesListNodes} params.recentProcessesListNodes
+   * @param {RecentProcessesListStates} params.recentProcessesListStates
    */
   constructor({
     handlers,
@@ -62,7 +63,7 @@ export class RecentProcessesListInit {
     recentProcessesListRender,
     recentProcessesListNodes,
     // recentProcessesListHandlers,
-    // recentProcessesListStates,
+    recentProcessesListStates,
     // recentProcessesListPrepare,
   }) {
     this.handlers = handlers;
@@ -72,7 +73,7 @@ export class RecentProcessesListInit {
     this.recentProcessesListRender = recentProcessesListRender;
     this.recentProcessesListNodes = recentProcessesListNodes;
     // this.recentProcessesListHandlers = recentProcessesListHandlers;
-    // this.recentProcessesListStates = recentProcessesListStates;
+    this.recentProcessesListStates = recentProcessesListStates;
     // this.recentProcessesListPrepare = recentProcessesListPrepare;
   }
 
@@ -114,7 +115,7 @@ export class RecentProcessesListInit {
       // Init all initiable components...
       this.recentProcessesListRender.init(initParams);
       // this.recentProcessesListHandlers.init(initParams);
-      // this.recentProcessesListStates.init(initParams);
+      this.recentProcessesListStates.init(initParams);
       // this.recentProcessesListPrepare.init(initParams);
 
       this.initDomNodeActions();
@@ -149,6 +150,9 @@ export class RecentProcessesListInit {
 
   getDomNodeContent() {
     return `
+      <div id="recent-processes-list-empty" class="recent-processes-list-empty">No recent processes</div>
+      <div id="recent-processes-list-title" class="recent-processes-list-title">Recently viewed processes</div>
+      <div id="recent-processes-list" class="recent-processes-list"><!-- List placeholder --></div>
       <div id="recent-processes-list-tableau" class="recent-processes-list-tableau">
         <div id="recent-processes-list-actions" class="recent-processes-list-actions">
           <a id="addNewThread" title="Add new thread"><i class="fa fa-plus"></i></a>
@@ -156,8 +160,6 @@ export class RecentProcessesListInit {
         <div id="recent-processes-list-error" class="error"><!-- Error text comes here --></div>
         <div id="loader-splash" class="loader-splash full-cover bg-white"><div class="loader-spinner"></div></div>
       </div>
-      <div id="recent-processes-list-empty" class="recent-processes-list-empty">No recent processes</div>
-      <div id="recent-processes-list" class="recent-processes-list"><!-- List placeholder --></div>
     `;
   }
 

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListInit.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListInit.js
@@ -1,0 +1,225 @@
+// @ts-check
+
+// Import types only...
+/* eslint-disable no-unused-vars */
+import { RecentProcessesListRender } from './RecentProcessesListRender.js';
+import { RecentProcessesListNodes } from './RecentProcessesListNodes.js';
+// import { RecentProcessesListHandlers } from './RecentProcessesListHandlers.js';
+// import { RecentProcessesListStates } from './RecentProcessesListStates.js';
+// import { RecentProcessesListPrepare } from './RecentProcessesListPrepare.js';
+/* eslint-enable no-unused-vars */
+
+import * as CommonHelpers from '../../common/CommonHelpers.js';
+import { InitChunks } from '../../common/InitChunks.js';
+import { commonNotify } from '../../common/CommonNotify.js';
+
+const cssStyleUrls = [
+  // Styles urls...
+  '/assets/css/recent-processes.css',
+  // '/assets/css/recent-processes-recent-processes-list.css',
+];
+
+/** List of initilization steps.
+ * @type {string[]}
+ */
+const initChunksList = [
+  'component',
+  'cssStyle', // Loaded css module
+  'events', // Inited events
+  'dom', // Created required dom elements
+];
+
+export class RecentProcessesListInit {
+  /** Initializer
+   * @type {InitChunks}
+   */
+  initChunks = undefined; // new InitChunks(initChunksList, 'RecentProcessesList');
+
+  /** @type {TSharedHandlers} */
+  handlers = {};
+
+  /** @type {RecentProcessesListRender} */
+  recentProcessesListRender;
+  /** @type {RecentProcessesListNodes} */
+  recentProcessesListNodes;
+  // [>* @type {RecentProcessesListHandlers} <]
+  // recentProcessesListHandlers;
+  // // [>* @type {RecentProcessesListStates} <]
+  // recentProcessesListStates;
+  // [>* @type {RecentProcessesListPrepare} <]
+  // recentProcessesListPrepare;
+
+  /**
+   * @param {object} params
+   * @param {TSharedHandlers} params.handlers
+   * @param {string} [params.parentId]
+   * @param {RecentProcessesListRender} params.recentProcessesListRender
+   * @param {RecentProcessesListNodes} params.recentProcessesListNodes
+   */
+  constructor({
+    handlers,
+    parentId,
+    recentProcessesListRender,
+    recentProcessesListNodes,
+    // recentProcessesListHandlers,
+    // recentProcessesListStates,
+    // recentProcessesListPrepare,
+  }) {
+    this.handlers = handlers;
+    const thisId = [parentId, 'Init'].filter(Boolean).join('_');
+    this.initChunks = new InitChunks(initChunksList, thisId);
+    // Set parameters for future initalization (see `initComponent`)
+    this.recentProcessesListRender = recentProcessesListRender;
+    this.recentProcessesListNodes = recentProcessesListNodes;
+    // this.recentProcessesListHandlers = recentProcessesListHandlers;
+    // this.recentProcessesListStates = recentProcessesListStates;
+    // this.recentProcessesListPrepare = recentProcessesListPrepare;
+  }
+
+  /** Ensure the modal has initiazlized
+   * @return {Promise}
+   */
+  ensureInit() {
+    if (!this.initChunks.isWaitingOrInited()) {
+      this.doInit();
+    }
+    return this.initChunks.getInitPromise();
+  }
+
+  /** @return TEvents */
+  events() {
+    return this.initChunks.events;
+  }
+
+  /** Initialize the heaviest things (loading external css styles)
+   */
+  preInit() {
+    // return this.initCssStyle();
+  }
+
+  initComponent() {
+    if (!this.initChunks.isChunkStarted('component')) {
+      this.initChunks.startChunk('component');
+      /** @type {TRecentProcessesListInitParams} */
+      const initParams = {
+        handlers: this.handlers,
+        events: this.events(),
+        recentProcessesListRender: this.recentProcessesListRender,
+        recentProcessesListNodes: this.recentProcessesListNodes,
+        // recentProcessesListHandlers: this.recentProcessesListHandlers,
+        // recentProcessesListStates: this.recentProcessesListStates,
+        // recentProcessesListPrepare: this.recentProcessesListPrepare,
+      };
+
+      // Init all initiable components...
+      this.recentProcessesListRender.init(initParams);
+      // this.recentProcessesListHandlers.init(initParams);
+      // this.recentProcessesListStates.init(initParams);
+      // this.recentProcessesListPrepare.init(initParams);
+
+      this.initDomNodeActions();
+
+      // Finish initialization stage...
+      this.initChunks.finishChunk('component');
+    }
+  }
+
+  async initCssStyle() {
+    if (!this.initChunks.isChunkStarted('cssStyle')) {
+      this.initChunks.startChunk('cssStyle');
+      try {
+        const promises = cssStyleUrls.map((url) => CommonHelpers.addCssStyle(url));
+        await Promise.all(promises);
+      } catch (error) {
+        /** @param {Error} error */
+        // eslint-disable-next-line no-console
+        console.error('[RecentProcessesListInit:initCssStyle]', error);
+        // eslint-disable-next-line no-debugger
+        debugger;
+        commonNotify.showError(error);
+      }
+      /* // TODO
+       * await CommonHelpers.addCssStyle(cssStyleUrl);
+       */
+      // Wait animation frame to finish updating css styles...
+      const finishCssStyleChunk = this.initChunks.finishChunk.bind(this.initChunks, 'cssStyle');
+      window.requestAnimationFrame(finishCssStyleChunk);
+    }
+  }
+
+  getDomNodeContent() {
+    return `
+      <div id="recent-processes-list-tableau" class="recent-processes-list-tableau">
+        <div id="recent-processes-list-actions" class="recent-processes-list-actions">
+          <a id="addNewThread" title="Add new thread"><i class="fa fa-plus"></i></a>
+        </div>
+        <div id="recent-processes-list-error" class="error"><!-- Error text comes here --></div>
+        <div id="loader-splash" class="loader-splash full-cover bg-white"><div class="loader-spinner"></div></div>
+      </div>
+      <div id="recent-processes-list-empty" class="recent-processes-list-empty">No recent processes</div>
+      <div id="recent-processes-list" class="recent-processes-list"><!-- List placeholder --></div>
+    `;
+  }
+
+  initDomNodeActions() {
+    const rootNode = this.recentProcessesListNodes.getRootNode();
+    const { handlers } = this;
+    const { handleTitleActionClick } = handlers;
+    const actionElems = rootNode.querySelectorAll('.recent-processes-list-actions a');
+    actionElems.forEach((elem) => {
+      elem.addEventListener('click', handleTitleActionClick);
+    });
+  }
+
+  initDomNode() {
+    if (!this.initChunks.isChunkStarted('dom')) {
+      this.initChunks.startChunk('dom');
+      const rootNode = this.recentProcessesListNodes.getRootNode();
+      // Set dafault classes...
+      rootNode.classList.toggle('loading', true);
+      rootNode.classList.toggle('empty', true);
+      // Create content...
+      const html = this.getDomNodeContent();
+      rootNode.innerHTML = html;
+      // Finish nitialization stage...
+      this.initChunks.finishChunk('dom');
+    }
+  }
+
+  initEvents() {
+    if (!this.initChunks.isChunkStarted('events')) {
+      // NOTE: Can't work without initialized dom!
+      this.initDomNode();
+      this.initChunks.startChunk('events');
+      /* // TODO
+       * // Link close modal button handler (TODO: To use more specific class name?)...
+       * const closeEl = this.getModalNodeElementByClass('close');
+       * closeEl.addEventListener('click', this.getBoundHideModal());
+       */
+      this.initChunks.finishChunk('events');
+    }
+  }
+
+  /** Initialize module.
+   */
+  doInit() {
+    if (!this.initChunks.isWaitingOrInited()) {
+      this.initChunks.start();
+      this.initCssStyle() // TODO
+        // Promise.resolve() // Temporarily: empty promise (replace with first initialization stage, see `CommonModal` as example)
+        .then(() => {
+          // Create all dom nodes...
+          this.initDomNode();
+          // Init events...
+          this.initEvents();
+          // Create all dom nodes...
+          return this.initComponent();
+        })
+        // TODO: Catch error with initFailed?
+        .catch((error) => {
+          this.initChunks.initFailed(error);
+        });
+      // NOTE: Initialization should be finished on all init chanks finish, in `initChunks.initFinished`.
+    }
+  }
+}

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListLoader.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListLoader.js
@@ -1,0 +1,89 @@
+// @ts-check
+
+// import * as CommonHelpers from '../../common/CommonHelpers.js';
+// import { commonNotify } from '../../common/CommonNotify.js';
+
+import { getActualSortedRecentProcesses } from '../../common/RecentProcesses.js';
+
+import * as RecentProcessesListConstants from './RecentProcessesListConstants.js';
+// import { RecentProcessesListData } from './RecentProcessesListData.js';
+import { RecentProcessesListStates } from './RecentProcessesListStates.js';
+
+export const RecentProcessesListLoader = /** @lends RecentProcessesListLoader */ {
+  /**
+   * @return {Promise<TRecentProcesses>}
+   */
+  loadRecentProcesses() {
+    // Emulate async load (for potential future upscaling)...
+    const recentProcesses = getActualSortedRecentProcesses();
+    return Promise.resolve(recentProcesses);
+  },
+
+  /** Load processes data
+   * @param {TRecentProcesses} recentProcesses
+   * @return {Promise<TProcessAttributes[]>}
+   */
+  loadProcessesAttributes(recentProcesses) {
+    const ids = recentProcesses.map(({ id }) => id);
+    const idsList = ids.join(',');
+    const { processesAttributesApiUrl: urlBase } = RecentProcessesListConstants;
+    /* // TODO: Use query params?
+     * const loadParams = {
+     *   ids,
+     * };
+     * const urlQuery = CommonHelpers.makeQuery(loadParams, { addQuestionSymbol: true });
+     */
+    const url = urlBase + idsList; // urlQuery;
+    /* console.log('[RecentProcessesListLoader:loadProcessesAttributes]: start', {
+     *   ids,
+     *   idsList,
+     *   url,
+     * });
+     */
+    RecentProcessesListStates.setLoading(true);
+    return fetch(url)
+      .then((res) => {
+        const { ok, status, statusText } = res;
+        if (!ok) {
+          // Something went wrong?
+          const reason =
+            [statusText, status && 'status: ' + status].filter(Boolean).join(', ') ||
+            'Unknown error';
+          const error = new Error('Data loading error: ' + reason);
+          // eslint-disable-next-line no-console
+          console.error('[RecentProcessesListLoader:loadProcessesAttributes]: error (on then)', {
+            reason,
+            res,
+            url,
+          });
+          // eslint-disable-next-line no-debugger
+          debugger;
+          throw error;
+        }
+        // All is ok...
+        return res.json();
+      })
+      .then((/** @type {TProcessAttributes[]} */ data) => {
+        /* console.log('[RecentProcessesListLoader:loadProcessesAttributes]: data', {
+         *   data,
+         *   ids,
+         *   url,
+         * });
+         */
+        return data;
+      })
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('[RecentProcessesListLoader:loadProcessesAttributes]: error (catched)', {
+          error,
+          url,
+        });
+        // eslint-disable-next-line no-debugger
+        debugger;
+        throw error;
+      })
+      .finally(() => {
+        RecentProcessesListStates.setLoading(false);
+      });
+  },
+};

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListNodes.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListNodes.js
@@ -1,0 +1,60 @@
+// @ts-check
+
+export const RecentProcessesListNodes = {
+  /** @type {Element} */
+  rootNode: undefined,
+  /** @type {Element} */
+  errorNode: undefined,
+
+  /**
+   * @param {Element} rootNode
+   */
+  setRootNode(rootNode) {
+    if (!rootNode) {
+      const error = new Error('Passed undefined root node');
+      // eslint-disable-next-line no-console
+      console.error('[RecentProcessesListNodes:setRootNode]: error', error);
+      // eslint-disable-next-line no-debugger
+      debugger;
+      throw error;
+    }
+    this.rootNode = rootNode;
+  },
+
+  getRootNode() {
+    if (!this.rootNode) {
+      const error = new Error('Root node should be defined with setErrorNode');
+      // eslint-disable-next-line no-console
+      console.error('[RecentProcessesListNodes:getRootNode]: error', error);
+      // eslint-disable-next-line no-debugger
+      debugger;
+      throw error;
+    }
+    return this.rootNode;
+  },
+
+  getErrorNode() {
+    const rootNode = this.getRootNode();
+    return rootNode.querySelector('#recent-processes-list-error');
+  },
+
+  getEmptyInfoNode() {
+    const rootNode = this.getRootNode();
+    return rootNode.querySelector('#recent-processes-list-empty');
+  },
+
+  getRecentProcessesContainerNode() {
+    const rootNode = this.getRootNode();
+    return rootNode.querySelector('#recent-processes-container');
+  },
+
+  getRecentProcessesListNode() {
+    const rootNode = this.getRootNode();
+    return rootNode.querySelector('#recent-processes-list');
+  },
+
+  getLoaderSplashNode() {
+    const rootNode = this.getRootNode();
+    return rootNode.querySelector('#loader-splash');
+  },
+};

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListRender.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListRender.js
@@ -25,9 +25,9 @@ export class RecentProcessesListRender {
    * @return {string} - HTML content
    */
   renderRecentProcess(recentProcess) {
-    const { id, name, timestamp } = recentProcess;
+    const { id, name, time } = recentProcess;
     const dateTimeFormatter = this.getDateTimeFormatter();
-    const date = new Date(timestamp);
+    const date = new Date(time);
     const dateStr = dateTimeFormatter.format(date);
     const className = [
       // prettier-ignore

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListRender.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListRender.js
@@ -1,0 +1,114 @@
+// @ts-check
+
+import * as CommonConstants from '../../common/CommonConstants.js';
+import * as CommonHelpers from '../../common/CommonHelpers.js';
+
+import { RecentProcessesListData } from './RecentProcessesListData.js';
+import { RecentProcessesListNodes } from './RecentProcessesListNodes.js';
+// import { RecentProcessesListHelpers } from './RecentProcessesListHelpers.js';
+
+export class RecentProcessesListRender {
+  /** @type {Intl.DateTimeFormat} */
+  dateTimeFormatter;
+  getDateTimeFormatter() {
+    if (!this.dateTimeFormatter) {
+      this.dateTimeFormatter = new Intl.DateTimeFormat(
+        CommonConstants.dateTimeFormatLocale,
+        CommonConstants.dateTimeFormatOptions,
+      );
+    }
+    return this.dateTimeFormatter;
+  }
+
+  /** renderRecentProcess
+   * @param {TRecentProcess} recentProcess
+   * @return {string} - HTML content
+   */
+  renderRecentProcess(recentProcess) {
+    const { id, name, timestamp } = recentProcess;
+    const dateTimeFormatter = this.getDateTimeFormatter();
+    const date = new Date(timestamp);
+    const dateStr = dateTimeFormatter.format(date);
+    const className = [
+      // prettier-ignore
+      'recent-process-item',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const content = `
+          <div data-recent-process-id="${id}" id="recent-process-${id}" class="${className}">
+            <a href="/process/${id}">${name} <span class="date">(visited at ${dateStr})</span></a>
+            </div>
+          </div>
+        `;
+    /* console.log('[RecentProcessesListRender:renderHelpers:renderRecentProcess]', {
+     *   id,
+     *   name,
+     * });
+     */
+    return content;
+  }
+  /**
+   * @param {Error} error
+   */
+  renderError(error) {
+    // TODO: Set css class for id="processes-list-root" --> error, update local state
+    // TODO: Set global error status
+    const isError = !!error;
+    const rootNode = RecentProcessesListNodes.getRootNode();
+    rootNode.classList.toggle('has-error', isError);
+    const errorNode = RecentProcessesListNodes.getErrorNode();
+    const errorText = error ? error.message || String(error) : '';
+    // DEBUG: Show error in console
+    if (errorText) {
+      // eslint-disable-next-line no-console
+      console.error('[RecentProcessesListRender:renderError]: got the error', {
+        error,
+        errorText,
+      });
+      // eslint-disable-next-line no-debugger
+      debugger;
+      /* // NOTE: Show error only when it has occured (eg in `RecentProcessesListHandlers`), not when it's rendering.
+       * commonNotify.showError(errorText);
+       */
+    }
+    // Update (or clear) error block content...
+    errorNode.innerHTML = errorText;
+  }
+
+  /** renderData -- Render all recent processes (or append data)
+   * @param {object} opts
+   * @param {boolean} [opts.append] - Append data to the end of the table (default behavior: replace)
+   */
+  renderData(opts = {}) {
+    const { recentProcesses } = RecentProcessesListData;
+    const recentProcessesListNode = RecentProcessesListNodes.getRecentProcessesListNode();
+    const content = recentProcesses.map(this.renderRecentProcess.bind(this)).join('\n');
+    /* // DEBUG
+     * const rootNode = RecentProcessesListNodes.getRootNode();
+     * console.log('[RecentProcessesListRender:renderData]', {
+     *   rootNode,
+     *   recentProcessesListNode,
+     *   content,
+     *   recentProcesses,
+     * });
+     */
+    if (!opts.append) {
+      // Replace data...
+      recentProcessesListNode.innerHTML = content; // Insert content just as raw html
+    } else {
+      // Append new data (will be used for incremental update)...
+      const contentNodes = CommonHelpers.htmlToElements(content);
+      recentProcessesListNode.append.apply(recentProcessesListNode, contentNodes);
+    }
+  }
+
+  /** @param {TRecentProcessesListInitParams} initParams */
+  init(initParams) {
+    // TODO: Check for `hasInited` before cruical operations?
+    const { handlers, events } = initParams;
+    // Save handlers and events...
+    this.handlers = handlers;
+    this.events = events;
+  }
+}

--- a/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListStates.js
+++ b/bw_matchbox/assets/modules/components/RecentProcesses/RecentProcessesListStates.js
@@ -1,0 +1,87 @@
+// @ts-check
+
+// Import types only...
+/* eslint-disable no-unused-vars */
+import { RecentProcessesListRender } from './RecentProcessesListRender.js';
+/* eslint-enable no-unused-vars */
+
+import { RecentProcessesListData } from './RecentProcessesListData.js';
+// import { RecentProcessesListHelpers } from './RecentProcessesListHelpers.js';
+import { RecentProcessesListNodes } from './RecentProcessesListNodes.js';
+
+export const RecentProcessesListStates = {
+  /** @type {TSharedHandlers} */
+  handlers: undefined,
+
+  /** @type {TEvents} */
+  events: undefined,
+
+  /** @type {number} */
+  loadingLevel: 0,
+
+  /** @type {RecentProcessesListRender} */
+  recentProcessesListRender: undefined,
+  // [>* @type {RecentProcessesListNodes} <]
+  // recentProcessesListNodes: undefined,
+  // [>* @type {RecentProcessesListStates} <]
+  // recentProcessesListStates: undefined,
+  // [>* @type {RecentProcessesListHandlers} <]
+  // recentProcessesListHandlers: undefined,
+  // [>* @type {RecentProcessesListPrepare} <]
+  // recentProcessesListPrepare: undefined,
+
+  /**
+   * @param {boolean} isLoading
+   */
+  setLoading(isLoading) {
+    this.loadingLevel += isLoading ? 1 : -1;
+    const setLoading = this.loadingLevel > 0;
+    // Set css class for id="processes-list-root" --> loading, set local status
+    const rootNode = RecentProcessesListNodes.getRootNode();
+    rootNode.classList.toggle('loading', setLoading);
+    RecentProcessesListData.isLoading = setLoading;
+    this.events.emit('loading', setLoading);
+  },
+
+  /**
+   * @param {boolean} hasData
+   */
+  setHasData(hasData) {
+    // Set css class for root node, update local state
+    const rootNode = RecentProcessesListNodes.getRootNode();
+    rootNode.classList.toggle('empty', !hasData);
+    RecentProcessesListData.hasData = hasData;
+    this.events.emit('hasData', hasData);
+  },
+
+  /** setEmpty -- Shorthand for `setHasData`
+   * @param {boolean} isEmpty
+   */
+  setEmpty(isEmpty) {
+    this.setHasData(!isEmpty);
+  },
+
+  /**
+   * @param {Error} error
+   */
+  setError(error) {
+    RecentProcessesListData.isError = !!error;
+    RecentProcessesListData.error = error;
+    this.recentProcessesListRender.renderError(error);
+    this.events.emit('error', error);
+  },
+
+  clearData() {
+    this.setHasData(false);
+    // this.recentProcessesListRender.clearRenderedData();
+  },
+
+  /** @param {TRecentProcessesListInitParams} initParams */
+  init(initParams) {
+    const { events, handlers, recentProcessesListRender } = initParams;
+    this.events = events;
+    this.handlers = handlers;
+    this.recentProcessesListRender = recentProcessesListRender;
+    // TODO: Update all the dynamic parameters...
+  },
+};

--- a/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsData.js
+++ b/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsData.js
@@ -81,7 +81,7 @@ export const ThreadCommentsData = {
   totalComments: 0,
   totalThreads: 0,
 
-  // Commpn params...
+  // Common params...
   error: undefined,
   isError: false,
   isLoading: true,

--- a/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsRender.js
+++ b/bw_matchbox/assets/modules/components/ThreadComments/ThreadCommentsRender.js
@@ -2,7 +2,6 @@
 
 import * as CommonConstants from '../../common/CommonConstants.js';
 import * as CommonHelpers from '../../common/CommonHelpers.js';
-import { commonNotify } from '../../common/CommonNotify.js';
 
 import { ThreadCommentsData } from './ThreadCommentsData.js';
 import { ThreadCommentsNodes } from './ThreadCommentsNodes.js';

--- a/bw_matchbox/assets/modules/pages/ProcessDetailPage/@types/TInitParams.d.ts
+++ b/bw_matchbox/assets/modules/pages/ProcessDetailPage/@types/TInitParams.d.ts
@@ -1,5 +1,5 @@
 interface TInitParams {
   threadComments: ThreadComments;
   callbacks: TSharedHandlers;
-  sharedParams: TSharedParams;
+  sharedParams: TProcessDetailPageSharedParams;
 }

--- a/bw_matchbox/assets/modules/pages/ProcessDetailPage/@types/TProcessDetailPageSharedParams.d.ts
+++ b/bw_matchbox/assets/modules/pages/ProcessDetailPage/@types/TProcessDetailPageSharedParams.d.ts
@@ -1,4 +1,4 @@
-interface TSharedParams {
+interface TProcessDetailPageSharedParams {
   addAttributeUrl: string;
   markMatchTypeUrl: string;
   markMatchedUrl: string;
@@ -8,4 +8,5 @@ interface TSharedParams {
   currentRole: string;
   currentUser: string;
   currentProcess: number;
+  currentProcessName: string;
 }

--- a/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPage.js
+++ b/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPage.js
@@ -54,11 +54,10 @@ export class ProcessDetailPage {
 
     const { callbacks } = this;
 
-    const { isWaitlist, currentUser, currentRole, currentProcess, currentProcessName } =
-      sharedParams;
+    const { isWaitlist, currentUser, currentRole, currentProcess } = sharedParams;
 
-    // Store current process...
-    storeProcess(currentProcess, currentProcessName);
+    // Store current process for history...
+    storeProcess(currentProcess);
 
     const nodes = (this.nodes = new ProcessDetailPageNodes());
     const state = (this.state = new ProcessDetailPageState({

--- a/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPage.js
+++ b/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPage.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { storeProcess } from '../../common/StoredProcesses.js';
+import { storeProcess } from '../../common/RecentProcesses.js';
 
 import { ThreadComments } from '../../components/ThreadComments/ThreadComments.js';
 

--- a/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPage.js
+++ b/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPage.js
@@ -1,8 +1,6 @@
 // @ts-check
 
-// import * as CommonHelpers from '../../common/CommonHelpers.js';
-// import { commonModal } from '../../common/CommonModal.js';
-// import { commonNotify } from '../../common/CommonNotify.js';
+import { storeProcess } from '../../common/StoredProcesses.js';
 
 import { ThreadComments } from '../../components/ThreadComments/ThreadComments.js';
 
@@ -14,7 +12,7 @@ import { ProcessDetailPageNodes } from './ProcessDetailPageNodes.js';
 
 export class ProcessDetailPage {
   /** External data...
-   * @type {TSharedParams}
+   * @type {TProcessDetailPageSharedParams}
    */
   sharedParams = undefined;
 
@@ -39,7 +37,7 @@ export class ProcessDetailPage {
   handlers;
 
   /**
-   * @param {TSharedParams} sharedParams
+   * @param {TProcessDetailPageSharedParams} sharedParams
    */
   constructor(sharedParams) {
     /* // (Optional) Pre-initialize common submodules...
@@ -56,7 +54,11 @@ export class ProcessDetailPage {
 
     const { callbacks } = this;
 
-    const { isWaitlist, currentUser, currentRole, currentProcess } = sharedParams;
+    const { isWaitlist, currentUser, currentRole, currentProcess, currentProcessName } =
+      sharedParams;
+
+    // Store current process...
+    storeProcess(currentProcess, currentProcessName);
 
     const nodes = (this.nodes = new ProcessDetailPageNodes());
     const state = (this.state = new ProcessDetailPageState({

--- a/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPageHandlers.js
+++ b/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPageHandlers.js
@@ -180,7 +180,7 @@ export class ProcessDetailPageHandlers {
     const hasPanel = layoutNode.classList.contains('has-panel');
     const showPanel = !hasPanel;
     layoutNode.classList.toggle('has-panel', showPanel);
-    button.classList.toggle('turned', showPanel);
+    button.classList.toggle('active', showPanel);
     panel.classList.toggle('hidden', !showPanel);
     if (showPanel) {
       callbacks.ensureThreadComments();

--- a/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPageHandlers.js
+++ b/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPageHandlers.js
@@ -175,7 +175,7 @@ export class ProcessDetailPageHandlers {
   toggleCommentsPanel() {
     const { nodes, callbacks } = this;
     const layoutNode = nodes.getLayoutNode();
-    const panel = layoutNode.querySelector('#thread-comments-panel');
+    const panel = this.nodes.getThreadCommentsPanelNode();
     const button = layoutNode.querySelector('#toggle-side-panel-button');
     const hasPanel = layoutNode.classList.contains('has-panel');
     const showPanel = !hasPanel;

--- a/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPageHandlers.js
+++ b/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPageHandlers.js
@@ -8,7 +8,7 @@ import { WaitlistCommentDialog } from './WaitlistCommentDialog.js';
  * @property {TProcessDetailPageState} state
  * @property {TProcessDetailPageNodes} nodes
  * @property {TSharedHandlers} callbacks
- * @property {TSharedParams} sharedParams
+ * @property {TProcessDetailPageSharedParams} sharedParams
  * @property {TThreadComments} threadComments
  */
 
@@ -16,7 +16,7 @@ import { WaitlistCommentDialog } from './WaitlistCommentDialog.js';
  * @class ProcessDetailPageHandlers
  */
 export class ProcessDetailPageHandlers {
-  /** @type {TSharedParams} */
+  /** @type {TProcessDetailPageSharedParams} */
   sharedParams;
   /** @type {TProcessDetailPageState} */
   state;

--- a/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPageInit.js
+++ b/bw_matchbox/assets/modules/pages/ProcessDetailPage/ProcessDetailPageInit.js
@@ -101,7 +101,7 @@ export class ProcessDetailPageInit {
         })
         .catch((/** @type {Error} */ error) => {
           // eslint-disable-next-line no-console
-          console.error('[ProcessDetailPageInit:start] threadComments.ensureInit error', error);
+          console.error('[ProcessDetailPageInit:ensureThreadComments] ensureInit error', error);
           // eslint-disable-next-line no-debugger
           debugger;
           // Set error

--- a/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesList.js
+++ b/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesList.js
@@ -229,5 +229,6 @@ export const ProcessesList = {
     this.startAllModules();
     // Load data...
     ProcessesListDataLoad.loadData();
+    ProcessesListStates.setInited(true);
   },
 };

--- a/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListData.js
+++ b/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListData.js
@@ -25,6 +25,7 @@ export const ProcessesListData = {
   currentPage: 0,
   error: undefined,
   isError: false,
+  isInited: true,
   isLoading: true,
   hasData: false,
 

--- a/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListNodes.js
+++ b/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListNodes.js
@@ -2,27 +2,38 @@
 
 export const ProcessesListNodes = {
   getSearchBarNode() {
-    const node = /** @type {HTMLInputElement} */ (document.getElementById('query_string'));
-    return node;
+    return /** @type {HTMLInputElement} */ (document.getElementById('query_string'));
   },
 
+  getLayoutNode() {
+    return document.getElementById('processes-list-layout');
+  },
+
+  getRecentProcessesListNode() {
+    return document.getElementById('recent-processes-list');
+  },
+
+  getRecentProcessesListPanelNode() {
+    return document.getElementById('recent-processes-list-panel');
+  },
+
+  getRecentProcessesContainerNode() {
+    const recentProcessesListPanelNode = this.getRecentProcessesListPanelNode();
+    return recentProcessesListPanelNode.querySelector('#recent-processes-container');
+  },
   getTBodyNode() {
-    const node = document.getElementById('processes-list-table-body');
-    return node;
+    return document.getElementById('processes-list-table-body');
   },
 
   getRootNode() {
-    const node = document.getElementById('processes-list-root');
-    return node;
+    return document.getElementById('processes-list-root');
   },
 
   getNavigationNode() {
-    const node = document.getElementById('processes-list-navigation');
-    return node;
+    return document.getElementById('processes-list-navigation');
   },
 
   getErrorNode() {
-    const node = document.getElementById('processes-list-error');
-    return node;
+    return document.getElementById('processes-list-error');
   },
 };

--- a/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListStates.js
@@ -9,6 +9,15 @@ export const ProcessesListStates = {
   __id: 'ProcessesListStates',
 
   /**
+   * @param {boolean} isInited
+   */
+  setInited(isInited) {
+    const layoutNode = ProcessesListNodes.getLayoutNode();
+    layoutNode.classList.toggle('inited', isInited);
+    ProcessesListData.isInited = isInited;
+  },
+
+  /**
    * @param {boolean} isLoading
    */
   setLoading(isLoading) {

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -9,7 +9,7 @@
       <a
         id="toggle-side-panel-button"
         class="panels-layout-actions-button layout-actions-button activable"
-        title="Toggle history panel"
+        title="Toggle recently viewed processes history panel"
         onClick="window.ProcessesList.toggleHistoryPanel(this)"
       >
         <i class="fa fa-history icon-default"></i>

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -1,109 +1,131 @@
 {% include 'header.html' %}
 
-<div id="processes-list-root" class="container processes-list empty loading role-{{ config.role }} has-{{ 'proxy' if config.proxy else 'no-proxy' }}">
-  {% include 'navigation.html' %}
-  <div class="page-search">
-    <p><input type="text" class="u-full-width" placeholder="Enter value to search" value="{{ query_string }}" id="query_string" /></p>
-  </div>
-  <div class="page-filters">
-    <span class="radio-group order-by">
-      {# Controls for `order_by` parameter (name, location, product;
-      default is (empty) i.e. random (see `order-random` for
-      `.processes-list` root node. #}
-      <span class="radio-group-title-wrapper">
-        <label class="radio-group-title">Order by:</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="order_by" id="order_by_random" value="random" onChange="ProcessesList.onOrderByChange(this)">
-        <label for="order_by_random">Random</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="order_by" id="order_by_name" value="name" onChange="ProcessesList.onOrderByChange(this)">
-        <label for="order_by_name">Name</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="order_by" id="order_by_location" value="location" onChange="ProcessesList.onOrderByChange(this)">
-        <label for="order_by_location">Location</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="order_by" id="order_by_product" value="product" onChange="ProcessesList.onOrderByChange(this)">
-        <label for="order_by_product">Product</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="order_by" id="order_by_importance" value="importance" onChange="ProcessesList.onOrderByChange(this)">
-        <label for="order_by_importance">Network Importance</label>
-      </span>
-    </span>
-    <span class="radio-group filter-by">
-      {# Controls for `filter` parameter: `matched`, `unmatched`, or `waitlist`. #}
-      <span class="radio-group-title-wrapper">
-        <label class="radio-group-title">Filter by:</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="filter_by" id="filter_by_none" value="none" onChange="ProcessesList.onFilterByChange(this)">
-        <label for="filter_by_none">None</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="filter_by" id="filter_by_matched" value="matched" onChange="ProcessesList.onFilterByChange(this)">
-        <label for="filter_by_matched">Matched</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="filter_by" id="filter_by_unmatched" value="unmatched" onChange="ProcessesList.onFilterByChange(this)">
-        <label for="filter_by_unmatched">Unmatched</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="filter_by" id="filter_by_waitlist" value="waitlist" onChange="ProcessesList.onFilterByChange(this)">
-        <label for="filter_by_waitlist">Waitlist</label>
-      </span>
-    </span>
-    <span class="radio-group user-db">
-      {# Controls for `database` parameter: `Source`, `Target`, `Proxy`. #}
-      <span class="radio-group-title-wrapper">
-        <label class="radio-group-title">Database:</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="user-db" id="user-db-source" value="source" onChange="ProcessesList.onUserDbChange(this)">
-        <label for="user-db-source">Source</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="user-db" id="user-db-target" value="target" onChange="ProcessesList.onUserDbChange(this)">
-        <label for="user-db-target">Target</label>
-      </span>
-      <span class="radio-group-item">
-        <input type="radio" name="user-db" id="user-db-proxy" value="proxy" onChange="ProcessesList.onUserDbChange(this)">
-        <label for="user-db-proxy">Proxy</label>
-      </span>
-    </span>
-  </div>
-  <div id="processes-list-error" class="error">
-    <!-- Error text comes here -->
-  </div>
-  <div id="processes-list-table-empty" class="processes-list-table-empty">No data has loaded for current conditions</div>
-  <table id="processes-list-table" class="fixed-table processes-list-table" width="100%">
-    <thead>
-      <tr>
-        <th class="cell-name"><div>Name</div></th>
-        <th class="cell-location"><div>Location</div></th>
-        <th class="cell-unit"><div>Unit</div></th>
-        <th class="cell-matched">
-          <div class="cell-matched-title-source">Matched</div>
-          <div class="cell-matched-title-other">Reference product</div>
-        </th>
-      </tr>
-    </thead>
-    <tbody id="processes-list-table-body">
-      {# NOTE: Content is dynamically populated in client's js code, see `ProcessesListDataRender` #}
-    </tbody>
-  </table>
-  <div class="bottom-actions">
-    <div class="bottom-actions-links">
-      <a id="action-reload-random" onClick="ProcessesList.clearAndReloadData(this)">Reload random data</a>
-      <a id="action-load-more" onClick="ProcessesList.loadMoreData(this)">Load more<span id="available-records-info"></span></a>
-      <a id="action-clear-and-reload" onClick="ProcessesList.clearAndReloadData(this)">Reload</a>
-      <span id="show-total-records-number">Loaded all the available records (<span id="total-records-number"></span>)</span>
+<div id="processes-list-layout" class="panels-layout processes-list-layout">
+
+  {% include 'recent-processes-panel.html' %}
+
+  <div id="processes-list-wrapper" class="panels-layout-main panels-layout-container">
+    <div class="panels-layout-actions">
+      <a
+        id="toggle-side-panel-button"
+        class="panels-layout-actions-button layout-actions-button activable"
+        title="Toggle history panel"
+        onClick="window.ProcessesList.toggleHistoryPanel(this)"
+      >
+        <i class="fa fa-history icon-default"></i>
+        <i class="fa fa-times icon-active"></i>
+      </a>
     </div>
-    <div id="loader-splash" class="loader-splash full-cover"><div class="loader-spinner"></div></div>
+
+    <div class="panels-layout-content panels-layout-full panels-layout-scrollable">
+      <div id="processes-list-root" class="container processes-list empty loading role-{{ config.role }} has-{{ 'proxy' if config.proxy else 'no-proxy' }}">
+        {% include 'navigation.html' %}
+        <div class="page-search">
+          <p><input type="text" class="u-full-width" placeholder="Enter value to search" value="{{ query_string }}" id="query_string" /></p>
+        </div>
+        <div class="page-filters">
+          <span class="radio-group order-by">
+            {# Controls for `order_by` parameter (name, location, product;
+            default is (empty) i.e. random (see `order-random` for
+            `.processes-list` root node. #}
+            <span class="radio-group-title-wrapper">
+              <label class="radio-group-title">Order by:</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="order_by" id="order_by_random" value="random" onChange="window.ProcessesList.onOrderByChange(this)">
+              <label for="order_by_random">Random</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="order_by" id="order_by_name" value="name" onChange="window.ProcessesList.onOrderByChange(this)">
+              <label for="order_by_name">Name</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="order_by" id="order_by_location" value="location" onChange="window.ProcessesList.onOrderByChange(this)">
+              <label for="order_by_location">Location</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="order_by" id="order_by_product" value="product" onChange="window.ProcessesList.onOrderByChange(this)">
+              <label for="order_by_product">Product</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="order_by" id="order_by_importance" value="importance" onChange="window.ProcessesList.onOrderByChange(this)">
+              <label for="order_by_importance">Network Importance</label>
+            </span>
+          </span>
+          <span class="radio-group filter-by">
+            {# Controls for `filter` parameter: `matched`, `unmatched`, or `waitlist`. #}
+            <span class="radio-group-title-wrapper">
+              <label class="radio-group-title">Filter by:</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="filter_by" id="filter_by_none" value="none" onChange="window.ProcessesList.onFilterByChange(this)">
+              <label for="filter_by_none">None</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="filter_by" id="filter_by_matched" value="matched" onChange="window.ProcessesList.onFilterByChange(this)">
+              <label for="filter_by_matched">Matched</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="filter_by" id="filter_by_unmatched" value="unmatched" onChange="window.ProcessesList.onFilterByChange(this)">
+              <label for="filter_by_unmatched">Unmatched</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="filter_by" id="filter_by_waitlist" value="waitlist" onChange="window.ProcessesList.onFilterByChange(this)">
+              <label for="filter_by_waitlist">Waitlist</label>
+            </span>
+          </span>
+          <span class="radio-group user-db">
+            {# Controls for `database` parameter: `Source`, `Target`, `Proxy`. #}
+            <span class="radio-group-title-wrapper">
+              <label class="radio-group-title">Database:</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="user-db" id="user-db-source" value="source" onChange="window.ProcessesList.onUserDbChange(this)">
+              <label for="user-db-source">Source</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="user-db" id="user-db-target" value="target" onChange="window.ProcessesList.onUserDbChange(this)">
+              <label for="user-db-target">Target</label>
+            </span>
+            <span class="radio-group-item">
+              <input type="radio" name="user-db" id="user-db-proxy" value="proxy" onChange="window.ProcessesList.onUserDbChange(this)">
+              <label for="user-db-proxy">Proxy</label>
+            </span>
+          </span>
+        </div>
+        <div id="processes-list-error" class="error">
+          <!-- Error text comes here -->
+        </div>
+        <div id="processes-list-table-empty" class="processes-list-table-empty">No data has loaded for current conditions</div>
+        <table id="processes-list-table" class="fixed-table processes-list-table" width="100%">
+          <thead>
+            <tr>
+              <th class="cell-name"><div>Name</div></th>
+              <th class="cell-location"><div>Location</div></th>
+              <th class="cell-unit"><div>Unit</div></th>
+              <th class="cell-matched">
+                <div class="cell-matched-title-source">Matched</div>
+                <div class="cell-matched-title-other">Reference product</div>
+              </th>
+            </tr>
+          </thead>
+          <tbody id="processes-list-table-body">
+            {# NOTE: Content is dynamically populated in client's js code, see `ProcessesListDataRender` #}
+          </tbody>
+        </table>
+        <div class="bottom-actions">
+          <div class="bottom-actions-links">
+            <a id="action-reload-random" onClick="window.ProcessesList.clearAndReloadData(this)">Reload random data</a>
+            <a id="action-load-more" onClick="window.ProcessesList.loadMoreData(this)">Load more<span id="available-records-info"></span></a>
+            <a id="action-clear-and-reload" onClick="window.ProcessesList.clearAndReloadData(this)">Reload</a>
+            <span id="show-total-records-number">Loaded all the available records (<span id="total-records-number"></span>)</span>
+          </div>
+          <div id="loader-splash" class="loader-splash full-cover"><div class="loader-spinner"></div></div>
+        </div>
+      </div>
+    </div>
   </div>
+
 </div>
 
 {# NOTE: All reusable modules and all related stuff like css are dynamically connecting as ES6 modules, inside the code #}

--- a/bw_matchbox/assets/templates/process_detail.html
+++ b/bw_matchbox/assets/templates/process_detail.html
@@ -47,11 +47,12 @@
     <div class="panels-layout-actions">
       <a
         id="toggle-side-panel-button"
-        class="panels-layout-actions-button layout-actions-button turnaround"
+        class="panels-layout-actions-button layout-actions-button activable"
         title="Show/hide comments panel"
         onClick="processDetailPage.callbacks.toggleCommentsPanel(this)"
       >
-        <i class="fa fa-chevron-left"></i>
+        <i class="fa fa-comments icon-default"></i>
+        <i class="fa fa-times icon-active"></i>
       </a>
     </div>
 

--- a/bw_matchbox/assets/templates/process_detail.html
+++ b/bw_matchbox/assets/templates/process_detail.html
@@ -2,54 +2,15 @@
 
 <div id="process-detail-layout" class="panels-layout process-detail-layout">
 
-  <div id="thread-comments-panel" class="panels-layout-side panels-layout-container panels-layout-right thread-comments-panel hidden">
-    <div id="thread-comments-panel-toolbar" class="thread-comments-panel-toolbar-wrapper">
-      <div class="thread-comments-toolbar">
-        <a
-          id="expandAllThreads"
-          title="Collapse/expand threads"
-          class="toolbar-icon"
-          onClick="processDetailPage.callbacks.expandAllThreads(this)"
-        >
-          <i class="fa fa-expand"></i>
-        </a>
-        <a
-          id="addNewThread"
-          title="Add new thread"
-          class="toolbar-icon"
-          onClick="processDetailPage.callbacks.addNewThread(this)"
-        >
-          <i class="fa fa-plus"></i>
-        </a>
-        <div class="group">
-          <label for="threadsSortMode">Sort by:</label>
-          <select
-            id="threadsSortMode"
-            onChange="processDetailPage.callbacks.setSortMode(this)"
-          >
-            <option value="resolved|modifiedDate" selected>Resolved / Modified date</option>
-            <option value="resolved|name">Resolved / Name</option>
-          </select>
-        </div>
-      </div>
-    </div>
-    <div class="panels-layout-content panels-layout-scrollable">
-      <div class="panels-layout-container container padded">
-        <div id="thread-comments" class="thread-comments">
-          <!-- Thread comments placehodler -->
-          <div id="temp-loader-splash" class="loader-splash"><div class="loader-spinner"></div></div>
-        </div>
-      </div>
-    </div>
-  </div>
+  {% include 'thread-comments-panel.html' %}
 
   <div id="process-detail" class="panels-layout-main panels-layout-container process-detail{{ ' waitlist' if ds.get('waitlist') }}">
     <div class="panels-layout-actions">
       <a
         id="toggle-side-panel-button"
         class="panels-layout-actions-button layout-actions-button activable"
-        title="Show/hide comments panel"
-        onClick="processDetailPage.callbacks.toggleCommentsPanel(this)"
+        title="Toggle comments panel"
+        onClick="window.processDetailPage.callbacks.toggleCommentsPanel(this)"
       >
         <i class="fa fa-comments icon-default"></i>
         <i class="fa fa-times icon-active"></i>
@@ -70,11 +31,11 @@
                 <div class="tools">
                   <div class="tools-wrapper">
                     {% if ds.database == source and config.role == 'editors'  %}
-                      <a id="mark-waitlist" class="tools-button {{ ' theme-primary' if not ds.get('waitlist') }}" onClick="processDetailPage.callbacks.markWaitlist(this)">{{ 'Waitlisted' if ds.waitlist else 'Waitlist' }}</a>
+                      <a id="mark-waitlist" class="tools-button {{ ' theme-primary' if not ds.get('waitlist') }}" onClick="window.processDetailPage.callbacks.markWaitlist(this)">{{ 'Waitlisted' if ds.waitlist else 'Waitlist' }}</a>
                       {% if not ds.matched %}
-                        <a id="manual-match" class="tools-button theme-primary" onClick="processDetailPage.callbacks.markMatched(this)">No match needed</a>
+                        <a id="manual-match" class="tools-button theme-primary" onClick="window.processDetailPage.callbacks.markMatched(this)">No match needed</a>
                         {% if same_name_count %}
-                          <a id="manual-multi-match" class="tools-button theme-primary" onClick="processDetailPage.callbacks.markAllMatched(this)">Mark all matched</a>
+                          <a id="manual-multi-match" class="tools-button theme-primary" onClick="window.processDetailPage.callbacks.markAllMatched(this)">Mark all matched</a>
                         {% endif %}
                         <a id="match-button" class="tools-button theme-primary" href="{{ url_for('match', source=ds.id)}}">Match</a>
                       {% else %}

--- a/bw_matchbox/assets/templates/process_detail.html
+++ b/bw_matchbox/assets/templates/process_detail.html
@@ -241,6 +241,7 @@
     currentRole: '{{ config.role }}',
     currentUser: '{{ config.user }}',
     currentProcess: {{ ds.id }},
+    currentProcessName: '{{ ds.name }}', // TODO: To escape with `|replace("'", "\\'")`?
   };
 
   // Export to global scope (to access from generated html code handlers).

--- a/bw_matchbox/assets/templates/recent-processes-panel.html
+++ b/bw_matchbox/assets/templates/recent-processes-panel.html
@@ -1,0 +1,42 @@
+<div id="recent-processes-list-panel" class="panels-layout-side panels-layout-container panels-layout-right recent-processes-list-panel hidden">
+  {#
+  <div id="recent-processes-list-panel-toolbar" class="recent-processes-list-panel-toolbar-wrapper">
+    <div class="recent-processes-list-toolbar">
+      <a
+        id="expandAllThreads"
+        title="Collapse/expand threads"
+        class="toolbar-icon"
+        onClick="processDetailPage.callbacks.expandAllThreads(this)"
+      >
+        <i class="fa fa-expand"></i>
+      </a>
+      <a
+        id="addNewThread"
+        title="Add new thread"
+        class="toolbar-icon"
+        onClick="processDetailPage.callbacks.addNewThread(this)"
+      >
+        <i class="fa fa-plus"></i>
+      </a>
+      <div class="group">
+        <label for="threadsSortMode">Sort by:</label>
+        <select
+          id="threadsSortMode"
+          onChange="processDetailPage.callbacks.setSortMode(this)"
+        >
+          <option value="resolved|modifiedDate" selected>Resolved / Modified date</option>
+          <option value="resolved|name">Resolved / Name</option>
+        </select>
+      </div>
+    </div>
+  </div>
+  #}
+  <div class="panels-layout-content panels-layout-scrollable">
+    <div class="panels-layout-container container padded">
+      <div id="recent-processes-container" class="recent-processes-container">
+        <!-- Recent processes placehodler -->
+        <div id="temp-loader-splash" class="loader-splash"><div class="loader-spinner"></div></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/bw_matchbox/assets/templates/thread-comments-panel.html
+++ b/bw_matchbox/assets/templates/thread-comments-panel.html
@@ -1,0 +1,40 @@
+<div id="thread-comments-panel" class="panels-layout-side panels-layout-container panels-layout-right thread-comments-panel hidden">
+  <div id="thread-comments-panel-toolbar" class="thread-comments-panel-toolbar-wrapper">
+    <div class="thread-comments-toolbar">
+      <a
+        id="expandAllThreads"
+        title="Collapse/expand threads"
+        class="toolbar-icon"
+        onClick="processDetailPage.callbacks.expandAllThreads(this)"
+      >
+        <i class="fa fa-expand"></i>
+      </a>
+      <a
+        id="addNewThread"
+        title="Add new thread"
+        class="toolbar-icon"
+        onClick="processDetailPage.callbacks.addNewThread(this)"
+      >
+        <i class="fa fa-plus"></i>
+      </a>
+      <div class="group">
+        <label for="threadsSortMode">Sort by:</label>
+        <select
+          id="threadsSortMode"
+          onChange="processDetailPage.callbacks.setSortMode(this)"
+        >
+          <option value="resolved|modifiedDate" selected>Resolved / Modified date</option>
+          <option value="resolved|name">Resolved / Name</option>
+        </select>
+      </div>
+    </div>
+  </div>
+  <div class="panels-layout-content panels-layout-scrollable">
+    <div class="panels-layout-container container padded">
+      <div id="thread-comments" class="thread-comments">
+        <!-- Thread comments placehodler -->
+        <div id="temp-loader-splash" class="loader-splash"><div class="loader-spinner"></div></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/bw_matchbox/webapp.py
+++ b/bw_matchbox/webapp.py
@@ -560,7 +560,7 @@ def processes():
     elif order_by == "importance":
         limit = limit or 250
         offset = offset or 0
-        qs = [bd.get_node(id=id_)._document for _, id_ in pr[offset : offset + limit]]
+        qs = [bd.get_node(id=id_)._document for _, id_ in pr[offset: offset + limit]]
         qs = apply_filter_to_qs(qs, filter_arg)
         total_records = len(bd.Database(config["source"]))
     else:
@@ -642,6 +642,16 @@ def search():
             table_data=table_data,  # =bd.Database(search_db).search(q, limit=100),
             query_string=q,
         )
+
+
+@matchbox_app.route("/processes-attributes-json/<ids_list_str>", methods=["GET"])
+@auth.login_required
+def processes_attributes_json(ids_list_str: str):
+    # ids_list_str = flask.request.args.get("ids")  # TODO: Use arguments? (Like `?ids={...}`?)
+    ids_list = map(int, ids_list_str.split(","))
+    attrs_list = map(format_process, ids_list)
+    response_data = list(attrs_list)
+    return flask.jsonify(response_data)
 
 
 @matchbox_app.route("/process-attributes-json/<id>", methods=["GET"])


### PR DESCRIPTION
Viewed processes data stored in cookie named `recent-processes` (constants parameter `storeRecentProcessesCookieName`) in format:

```json
[{"id":28370,"time":1700559534730},{"id":28189,"time":1700559524486},{"id":27712,"time":1700558454588}]
```

This data updated on each process view. Stored only 20 last records, sorted in order of time (the recents are the first). See parameter `storeRecentProcessesCount` (it's possible to use `storeRecentProcessesForDays` parameter to specify time to store records.

Server api method `processes-attributes-json` used to extend stored data with process names.