### PR TITLE
Issue #156: Allocation workflow

### DIFF
--- a/bw_matchbox/assets/css/common.css
+++ b/bw_matchbox/assets/css/common.css
@@ -19,9 +19,9 @@
   /* Default table cell widths */
   --common-table-cell-amount-width: 14em;
   --common-table-cell-name-width: auto;
-  --common-table-cell-location-width: 12em;
-  --common-table-cell-unit-width: 5em;
-  --common-table-cell-matched-width: 8em;
+  --common-table-cell-location-width: 8%; /* 4em; */
+  --common-table-cell-unit-width: 12%; /* 5em; */
+  --common-table-cell-matched-width: 15%; /* 9em; */
   /* Misc */
   --minor-border-color: #eee;
   /** Comments */

--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -39,6 +39,14 @@
   opacity: 0.5;
 }
 
+/* Allocated cells */
+.processes-list .processes-list-table .allocate-cell .fa {
+  opacity: 0.5;
+}
+.processes-list .processes-list-table .allocate-cell.allocated {
+  color: var(--common-success-color);
+}
+
 /* Loading state: disable some elements... */
 .processes-list > * {
   transition: all var(--common-animation-time);
@@ -76,6 +84,10 @@
   pointer-events: none;
   opacity: 0.5;
 }
+/* Show/hide unallocated db */
+.processes-list:not(.hasUnallocated) #database-option-user-db-unallocated {
+  display: none;
+}
 
 /* Table */
 .processes-list .processes-list-table {
@@ -86,8 +98,10 @@
   width: 100%;
   margin-bottom: 0;
 }
-/* Display 'Matched' or 'Reference product' title for 'matched' column respectively by the `userDb` propery. */
+/* Display 'Allocate', 'Matched' or 'Reference product' title for 'matched' column respectively by the `userDb` properly. */
+.processes-list:not(.userDb-unallocated) .processes-list-table .cell-matched-title-unallocated,
 .processes-list.userDb-source .processes-list-table .cell-matched-title-other,
+.processes-list.userDb-unallocated .processes-list-table .cell-matched-title-other,
 .processes-list:not(.userDb-source) .processes-list-table .cell-matched-title-source {
   display: none;
 }

--- a/bw_matchbox/assets/css/processes-list.css
+++ b/bw_matchbox/assets/css/processes-list.css
@@ -39,14 +39,6 @@
   opacity: 0.5;
 }
 
-/* Allocated cells */
-.processes-list .processes-list-table .allocate-cell .fa {
-  opacity: 0.5;
-}
-.processes-list .processes-list-table .allocate-cell.allocated {
-  color: var(--common-success-color);
-}
-
 /* Loading state: disable some elements... */
 .processes-list > * {
   transition: all var(--common-animation-time);
@@ -93,11 +85,6 @@
 .processes-list .processes-list-table {
   margin: 20px 0;
 }
-.processes-list .processes-list-table tr td:last-child div > .button {
-  display: block;
-  width: 100%;
-  margin-bottom: 0;
-}
 /* Display 'Allocate', 'Matched' or 'Reference product' title for 'matched' column respectively by the `userDb` properly. */
 .processes-list:not(.userDb-unallocated) .processes-list-table .cell-matched-title-unallocated,
 .processes-list.userDb-source .processes-list-table .cell-matched-title-other,
@@ -121,6 +108,26 @@
 }
 .processes-list .processes-list-table .cell-matched {
   width: var(--common-table-cell-matched-width);
+}
+.processes-list .processes-list-table .cell-matched div {
+  white-space: nowrap;
+}
+
+/* Allocated cells */
+.processes-list .processes-list-table .allocate-cell {
+  display: block;
+}
+.processes-list .processes-list-table .allocate-cell .fa {
+  opacity: 0.5;
+}
+.processes-list .processes-list-table .allocate-cell.allocated {
+  color: var(--common-success-color);
+}
+
+/* Customize table buttons */
+.processes-list .processes-list-table td .button {
+  padding: 0 15px;
+  margin: 0;
 }
 
 /* Filter controls section */

--- a/bw_matchbox/assets/modules/@types/TProcess.d.ts
+++ b/bw_matchbox/assets/modules/@types/TProcess.d.ts
@@ -11,4 +11,7 @@ interface TProcess {
   proxy_url?: string; // null
   unit: string; // 'USD'
   waitlist: boolean; // false
+  // Issue #156: Unallocated properties...
+  allocated?: boolean; // ??? -- Can't see it in the server data (in the method `processes` of `webapp.py`)
+  allocate_url?: string; // 'allocate/149'
 }

--- a/bw_matchbox/assets/modules/pages/ProcessesList/@types/TUserDb.d.ts
+++ b/bw_matchbox/assets/modules/pages/ProcessesList/@types/TUserDb.d.ts
@@ -1,2 +1,2 @@
-type TUserDb = 'source' | 'target' | 'proxy';
+type TUserDb = 'source' | 'target' | 'proxy' | 'unallocated';
 type TUserDbString = 'none' | TUserDb;

--- a/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesList.js
+++ b/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesList.js
@@ -221,6 +221,7 @@ export const ProcessesList = {
    * @param {any} sharedParams
    */
   start(sharedParams) {
+    console.log('[ProcessesList:sharedParams]', sharedParams);
     // Save shared data for future use...
     ProcessesListData.sharedParams = sharedParams;
     // Fetch url query parameters...

--- a/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListDataRender.js
+++ b/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListDataRender.js
@@ -29,10 +29,23 @@ export const ProcessesListDataRender = {
       match_type, // 'No direct match available'
       matched, // false
       product,
+      allocated,
+      allocate_url,
     } = rowData;
+    /* // DEBUG: Test different allocated statuses (random value depended on process id)
+     * const allocated = Boolean(id % 2);
+     */
     const hasMatchType = !!match_type;
     const isSource = userDb === 'source';
-    if (!isSource) {
+    const isUnallocated = userDb === 'unallocated';
+    if (isUnallocated) {
+      if (!allocated) {
+        const allocateUrl = allocate_url || '/allocate/' + id;
+        return `<span class="allocate-cell unallocated"><a href="${allocateUrl}"><i class="fa fa-arrow-right"></i> Allocate</a></span>`;
+      } else {
+        return '<span class="allocate-cell allocated"><i class="fa fa-check"></i> Allocated</span>';
+      }
+    } else if (!isSource) {
       return product || '';
     } else if (isEditor) {
       const matchUrl = '/match/' + id;
@@ -43,7 +56,7 @@ export const ProcessesListDataRender = {
       return `<a
             class="${matchClass}"
             href="${matchUrl}">
-              <i class="fa-solid ${matchIcon}"></i>
+              <i class="fa ${matchIcon}"></i>
               ${matchText}
             </a>`;
     } else if (hasProxy) {

--- a/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListDataRender.js
+++ b/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListDataRender.js
@@ -41,9 +41,15 @@ export const ProcessesListDataRender = {
     if (isUnallocated) {
       if (!allocated) {
         const allocateUrl = allocate_url || '/allocate/' + id;
-        return `<span class="allocate-cell unallocated"><a href="${allocateUrl}"><i class="fa fa-arrow-right"></i> Allocate</a></span>`;
+        return `<span class="allocate-cell unallocated">
+          <a class="button button-primary" href="${allocateUrl}">
+            <i class="fa fa-arrow-right"></i> Allocate
+          </a>
+        </span>`;
       } else {
-        return '<span class="allocate-cell allocated"><i class="fa fa-check"></i> Allocated</span>';
+        return `<span class="allocate-cell allocated">
+          <i class="fa fa-check"></i> Allocated
+        </span>`;
       }
     } else if (!isSource) {
       return product || '';
@@ -83,12 +89,17 @@ export const ProcessesListDataRender = {
       // matched, // false
     } = rowData;
     const matchContent = this.renderMatchCellContent(rowData);
+    const matchString = matchContent
+      .replace(/<[^<>]*>/g, '')
+      .replace(/"/g, '&quote;')
+      .replace(/\s\s+/, ' ')
+      .trim();
     const content = `
           <tr>
-            <td><div><a href="/process/${id || ''}">${name || ''}</a></div></td>
-            <td><div>${location || ''}</div></td>
-            <td><div>${unit || ''}</div></td>
-            <td><div>${matchContent || ''}</div></td>
+            <td class="cell-name"><div><a href="/process/${id || ''}">${name || ''}</a></div></td>
+            <td class="cell-location"><div>${location || ''}</div></td>
+            <td class="cell-unit"><div>${unit || ''}</div></td>
+            <td class="cell-matched" title="${matchString}"><div>${matchContent || ''}</div></td>
           </tr>
         `;
     return content;

--- a/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListStates.js
+++ b/bw_matchbox/assets/modules/pages/ProcessesList/ProcessesListStates.js
@@ -318,8 +318,20 @@ export const ProcessesListStates = {
     return elem && elem.value;
   },
 
+  updateContainerClasses() {
+    const { sharedParams } = ProcessesListData;
+    const { databases } = sharedParams;
+    const { unallocated } = databases;
+    const hasUnallocated = !!unallocated;
+    const rootNode = ProcessesListNodes.getRootNode();
+    rootNode.classList.toggle('hasUnallocated', hasUnallocated);
+  },
+
   start() {
     // Update all the dynamic parameters...
+
+    // Set unallocated state...
+    this.updateContainerClasses();
 
     // Order by...
     this.updateDomCheckedOrderBy(undefined);

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -91,6 +91,11 @@
               <input type="radio" name="user-db" id="user-db-proxy" value="proxy" onChange="window.ProcessesList.onUserDbChange(this)">
               <label for="user-db-proxy">Proxy</label>
             </span>
+            <span class="radio-group-item" id="database-option-user-db-unallocated">
+              <input type="radio" name="user-db" id="user-db-unallocated" value="unallocated" onChange="window.ProcessesList.onUserDbChange(this)">
+              <label for="user-db-unallocated">Unallocated</label>
+            </span>
+            {# TODO: Add 'Allocate' control #}
           </span>
         </div>
         <div id="processes-list-error" class="error">
@@ -104,6 +109,7 @@
               <th class="cell-location"><div>Location</div></th>
               <th class="cell-unit"><div>Unit</div></th>
               <th class="cell-matched">
+                <div class="cell-matched-title-unallocated">Allocate</div>
                 <div class="cell-matched-title-source">Matched</div>
                 <div class="cell-matched-title-other">Reference product</div>
               </th>
@@ -147,7 +153,8 @@
       target: '{{ config.target }}',
       proxy: '{{ config.proxy }}',
       // Could be null or a string
-      unallocated: {{ unallocated|tojson }}
+      unallocated: '{{ config.source }}', // DEBUG
+      // unallocated: {{ unallocated|tojson }}
     },
     // hasProxy: {{ 'true' if config.proxy else 'false' }}, // Example
     currentRole: '{{ config.role }}',

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -105,13 +105,13 @@
         <table id="processes-list-table" class="fixed-table processes-list-table" width="100%">
           <thead>
             <tr>
-              <th class="cell-name"><div>Name</div></th>
-              <th class="cell-location"><div>Location</div></th>
-              <th class="cell-unit"><div>Unit</div></th>
+              <th class="cell-name" title="Name"><div>Name</div></th>
+              <th class="cell-location" title="Location"><div>Location</div></th>
+              <th class="cell-unit" title="Unit"><div>Unit</div></th>
               <th class="cell-matched">
-                <div class="cell-matched-title-unallocated">Allocate</div>
-                <div class="cell-matched-title-source">Matched</div>
-                <div class="cell-matched-title-other">Reference product</div>
+                <div class="cell-matched-title-unallocated" title="Allocate">Allocate</div>
+                <div class="cell-matched-title-source" title="Matched">Matched</div>
+                <div class="cell-matched-title-other" title="Reference product">Reference product</div>
               </th>
             </tr>
           </thead>

--- a/bw_matchbox/assets/templates/index.html
+++ b/bw_matchbox/assets/templates/index.html
@@ -153,8 +153,8 @@
       target: '{{ config.target }}',
       proxy: '{{ config.proxy }}',
       // Could be null or a string
-      unallocated: '{{ config.source }}', // DEBUG
-      // unallocated: {{ unallocated|tojson }}
+      unallocated: {{ unallocated|tojson }}
+      // unallocated: '{{ config.source }}', // DEBUG
     },
     // hasProxy: {{ 'true' if config.proxy else 'false' }}, // Example
     currentRole: '{{ config.role }}',


### PR DESCRIPTION
Added optional database switch for 'Unallocated' mode, styles and code to display extra 'Allocated' table column header and corresponding data for it (link or 'Already allocated' notification).

I assume that:

- The `sharedParams.databases.unallocated` field contains an (optional) database id.
- The returned data records for this databse contain fields `allocated` and `allocate_url` (I see the second one in webapp method `processes`, not the first).
- The 'Allocate' column displays when the database option for 'Unallocated' is selected only.